### PR TITLE
(MAINT) Add go.mod for theme and correct site mod

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 * text eol=lf
+# Images
 *.png binary
 *.gif binary
+# Fonts
+*.ttf binary
+*.woff binary
+*.woff2 binary

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/platenio/platen.io
+module github.com/platenio/platen
 
 go 1.19
 

--- a/modules/base/go.mod
+++ b/modules/base/go.mod
@@ -1,0 +1,3 @@
+module github.com/platenio/platen/modules/base
+
+go 1.18


### PR DESCRIPTION
Prior to this change, the go.mod for the site pointed to an incorrect URL and the base theme did not have its own go.mod, which made it impossible to use as a hugo module.

This change corrects both issues and ensures that fonts are treated as binary files by git instead of as plaintext.