### PR TITLE
(MAINT) Remove netlify ignore command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,6 @@
 base = "site/"
 publish = "public"
 command = "hugo --gc --minify"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../content/ ../data ../modules"
 
 [context.production.environment]
 HUGO_VERSION = "0.106.0"


### PR DESCRIPTION
The ignore command was preventing deploys from main and updating on every merge is fine.