### PR TITLE
(MAINT) Fix mobile view

### DIFF
--- a/modules/platen/assets/styles/mobile/_header.scss
+++ b/modules/platen/assets/styles/mobile/_header.scss
@@ -1,5 +1,5 @@
 @media screen and (max-width: $mobile-breakpoint) {
   .platen-header {
-    display: block;
+    display: block !important; 
   }
 }

--- a/modules/platen/assets/styles/normalize.css
+++ b/modules/platen/assets/styles/normalize.css
@@ -11,6 +11,7 @@
 html {
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
+  text-size-adjust: 100%; /* 2 */
 }
 
 /* Sections


### PR DESCRIPTION
Prior to this change, the mobile view for the `platen-header` had display set to hidden instead of block in mobile.

This change adds the `!important` directive to the CSS for the header on mobile, fixing the display.

It also adds `text-size-adjust` to the normalize CSS for compatibility, discovered while working on fixing the mobile view.