### PR TITLE
(GH-25) Add Itch presets

### DIFF
--- a/data/_params/memo.yaml
+++ b/data/_params/memo.yaml
@@ -74,11 +74,13 @@ front_matter:
         - /modules/platen/markup/columns:frontmatter/codeblock-group.json
         - /modules/platen/markup/details:frontmatter/codeblock.json
         - /modules/platen/markup/itch:frontmatter/image.json
+        - /modules/platen/markup/itch:frontmatter/preset.json
         - /modules/platen/markup/katex/block:frontmatter/codeblock.json
         - /modules/platen/markup/katex/inline:frontmatter/image.json
         - /modules/platen/markup/mermaid:frontmatter/codeblock.json
         - /modules/platen/markup/section:frontmatter/codeblock.json
         - /modules/platen/markup/tabs:frontmatter/codeblock-entry.json
         - /modules/platen/markup/tabs:frontmatter/codeblock-group.json
-      publish:     /frontmatter/platen.json
-      join_arrays: true
+      publish:         /frontmatter/platen.json
+      join_arrays:     true
+      resolve_schemas: true

--- a/data/platen/embeds/itch/UNCONQUERED.yaml
+++ b/data/platen/embeds/itch/UNCONQUERED.yaml
@@ -1,0 +1,11 @@
+
+title:            UNCONQUERED by Monkey's Paw Games
+# id:               1765719
+# square:           false
+# dark:             false
+linkback:         true
+background_color: "#d3d3ac"
+text_color:       "#000000"
+button_color:     "#e53b44"
+border_color:     "#fa5059"
+border_width:     3

--- a/modules/memo/layouts/partials/memo/frontmatter/merge.html
+++ b/modules/memo/layouts/partials/memo/frontmatter/merge.html
@@ -6,18 +6,23 @@
     earlier ones, favoring their values.
 */}}
 
-{{- $Params      := .                                  -}}
-{{- $Context     := $Params.Context                    -}}
-{{- $ConfigPaths := $Params.ConfigPaths                -}}
-{{- $JoinArrays  := $Params.JoinArrays | default false -}}
-{{- $configs     := slice                              -}}
-{{- $merged      := dict                               -}}
+{{- $Params         := .                                      -}}
+{{- $Context        := $Params.Context                        -}}
+{{- $ConfigPaths    := $Params.ConfigPaths                    -}}
+{{- $JoinArrays     := $Params.JoinArrays     | default false -}}
+{{- $ResolveSchemas := $Params.ResolveSchemas | default false -}}
+{{- $configs        := slice                                  -}}
+{{- $merged         := dict                                   -}}
 
 {{/* Retrieve the config asset so it's data can be unmarshalled for merging */}}
 {{- range $ConfigPath := $ConfigPaths -}}
   {{- $Resolving := dict "Context" $Context "ConfigPath" $ConfigPath -}}
   {{- with (partial "memo/frontmatter/resolve" $Resolving) -}}
     {{- $data   := .Content | transform.Unmarshal -}}
+    {{- if $ResolveSchemas -}}
+      {{- $ResolvingSchema := dict "Context" $Context "Config" $data                      -}}
+      {{- $data             = partial "memo/frontmatter/schemas/resolve" $ResolvingSchema -}}
+    {{- end -}}
     {{- $configs = $configs | append $data        -}}
   {{- end -}}
 {{- end -}}

--- a/modules/memo/layouts/partials/memo/frontmatter/publish.html
+++ b/modules/memo/layouts/partials/memo/frontmatter/publish.html
@@ -16,26 +16,40 @@
 {{- $JsonOptions:= dict "indent" "  " "noHTMLEscape" true -}}
 
 {{- range $options := $FrontMatter.configs -}}
-  {{- $Definition := $options.definition                              -}}
-  {{- $Publish    := $options.publish                                 -}}
-  {{- $joinArrays := $options.join_arrays | default $Input.JoinArrays -}}
-  {{- $merge      := $options.merge                                   -}}
+  {{- $Definition     := $options.definition                                  -}}
+  {{- $Publish        := $options.publish                                     -}}
+  {{- $ResolveSchemas := $options.resolve_schemas | default false             -}}
+  {{- $joinArrays     := $options.join_arrays     | default $Input.JoinArrays -}}
+  {{- $merge          := $options.merge                                       -}}
   {{- if $Definition -}}
     {{/* If the config defines definition without publish, reuse definition */}}
     {{- $publish   := $Publish | default $Definition                   -}}
     {{- $Resolving := dict "Context" $Context "ConfigPath" $Definition -}}
     {{- with (partial "memo/frontmatter/resolve" $Resolving) -}}
-      {{- $json := . | resources.Copy $publish -}}
-      {{- $_    := $json.Permalink             -}}
+      {{- if $ResolveSchemas -}}
+        {{- $config          := .Content | transform.Unmarshal                              -}}
+        {{- $ResolvingSchema := dict "Context" $Context "Config" $config                    -}}
+        {{- $config           = partial "memo/frontmatter/schemas/resolve" $ResolvingSchema -}}
+        {{- $config           = $config | jsonify $JsonOptions                              -}}
+        {{- $config           = $config | resources.FromString $Publish                     -}}
+        {{- $_               := $config.Permalink                                           -}}
+      {{- else -}}
+        {{- $json := . | resources.Copy $publish -}}
+        {{- $_    := $json.Permalink             -}}
+      {{- end -}}
     {{- end -}}
   {{- else if $merge -}}
     {{- if not (reflect.IsSlice $merge) -}}
       {{- $merge = slice $merge -}}
     {{- end -}}
-    {{- $mergeParams  := dict "Context" $Context "ConfigPaths" $merge "JoinArrays" $joinArrays -}}
-    {{- $mergedSchema := partial "memo/frontmatter/merge" $mergeParams                         -}}
-    {{- $mergedSchema  = $mergedSchema | jsonify $JsonOptions                                  -}}
-    {{- $mergedSchema  = $mergedSchema | resources.FromString $Publish                         -}}
-    {{- $_            := $mergedSchema.Permalink                                               -}}
+    {{- $mergeParams  := dict "Context"        $Context
+                              "ConfigPaths"    $merge
+                              "JoinArrays"     $joinArrays
+                              "ResolveSchemas" $ResolveSchemas
+    -}}
+    {{- $mergedSchema := partial "memo/frontmatter/merge" $mergeParams -}}
+    {{- $mergedSchema  = $mergedSchema | jsonify $JsonOptions          -}}
+    {{- $mergedSchema  = $mergedSchema | resources.FromString $Publish -}}
+    {{- $_            := $mergedSchema.Permalink                       -}}
   {{- end -}}
 {{- end -}}

--- a/modules/memo/layouts/partials/memo/frontmatter/schemas/_munge.html
+++ b/modules/memo/layouts/partials/memo/frontmatter/schemas/_munge.html
@@ -1,0 +1,18 @@
+{{- $Resolving   := .                  -}}
+{{- $Context     := $Resolving.Context -}}
+{{- $entry       := $Resolving.Entry   -}}
+{{- $mungedEntry := $entry             -}}
+
+{{- range $Key, $Value := $entry -}}
+  {{- $KeyIsSchema   := eq $Key "schema" -}}
+  {{- $ValueIsScalar := and (not (reflect.IsMap $Value)) (not (reflect.IsSlice $Value)) -}}
+  {{- if and $KeyIsSchema $ValueIsScalar -}}
+    {{- $Resolving := dict "Context" $Context "ConfigPath" $Value -}}
+    {{- with (partial "memo/frontmatter/resolve" $Resolving) -}}
+      {{- $mungedValue := .Content | transform.Unmarshal -}}
+      {{- $mungedEntry  = merge $mungedEntry (dict $Key $mungedValue) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $mungedEntry -}}

--- a/modules/memo/layouts/partials/memo/frontmatter/schemas/resolve.html
+++ b/modules/memo/layouts/partials/memo/frontmatter/schemas/resolve.html
@@ -1,0 +1,18 @@
+{{- $Params       := .               -}}
+{{- $Context      := $Params.Context -}}
+{{- $Config       := $Params.Config  -}}
+{{- $mungedConfig := $Config         -}}
+
+{{- range $ConfigKey, $Entries := $Config -}}
+  {{- if in $ConfigKey ".data." -}}
+    {{- $mungedEntries := slice -}}
+    {{- range $entry := $Entries -}}
+      {{- $Munging      := dict "Context" $Context "Entry" $entry             -}}
+      {{- $munged       := partial "memo/frontmatter/schemas/_munge" $Munging -}}
+      {{- $mungedEntries = $mungedEntries | append $munged                    -}}
+    {{- end -}}
+    {{- $mungedConfig = merge $mungedConfig (dict $ConfigKey $mungedEntries) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $mungedConfig -}}

--- a/modules/platen/_docs/markup/_index.md
+++ b/modules/platen/_docs/markup/_index.md
@@ -24,6 +24,24 @@ Memo:
           - ./tabs:frontmatter/codeblock-entry.json
           - ./tabs:frontmatter/codeblock-group.json
         publish: /frontmatter/platen/content/snippets.json
+      - merge:
+          - ./art:frontmatter/image-local.json
+          - ./art:frontmatter/image-remote.json
+          - ./buttons:frontmatter/image.json
+          - ./columns:frontmatter/codeblock-entry.json
+          - ./columns:frontmatter/codeblock-group.json
+          - ./details:frontmatter/codeblock.json
+          - ./itch:frontmatter/preset.json
+          - ./itch:frontmatter/image.json
+          - ./katex/block:frontmatter/codeblock.json
+          - ./katex/inline:frontmatter/image.json
+          - ./mermaid:frontmatter/codeblock.json
+          - ./section:frontmatter/codeblock.json
+          - ./tabs:frontmatter/codeblock-entry.json
+          - ./tabs:frontmatter/codeblock-group.json
+        publish:         /frontmatter/platen/markup.json
+        resolve_schemas: true
+        join_arrays:     true
 ---
 
 This section documents the special markup that Platen supports. The markup transforms your Markdown

--- a/modules/platen/_docs/markup/art/index.md
+++ b/modules/platen/_docs/markup/art/index.md
@@ -17,6 +17,10 @@ Memo:
           - frontmatter/image-local.json
           - frontmatter/image-remote.json
         publish: /frontmatter/platen/content/snippets/art.json
+      - merge:
+          - frontmatter/image-local.json
+          - frontmatter/image-remote.json
+        publish: /frontmatter/platen/markup/art.json
   MungeTitle: false
   Kind: Renderer.Image
   Aliases: []

--- a/modules/platen/_docs/markup/buttons/index.md
+++ b/modules/platen/_docs/markup/buttons/index.md
@@ -14,6 +14,9 @@ Memo:
         publish:    /frontmatter/platen/content/snippets/buttons/image.json
       - merge:      frontmatter/image.json
         publish:    /frontmatter/platen/content/snippets/buttons.json
+      - merge:
+          - frontmatter/image.json
+        publish: /frontmatter/platen/markup/buttons.json
   Kind: Renderer.Image
   Aliases:
     - btn

--- a/modules/platen/_docs/markup/columns/index.md
+++ b/modules/platen/_docs/markup/columns/index.md
@@ -18,6 +18,10 @@ Memo:
           - frontmatter/codeblock-group.json
           - frontmatter/codeblock-entry.json
         publish: /frontmatter/platen/content/snippets/columns.json
+      - merge:
+          - frontmatter/codeblock-group.json
+          - frontmatter/codeblock-entry.json
+        publish: /frontmatter/platen/markup/columns.json
   MungeTitle: false
   Kind: Renderer.Codeblock
   Attributes:

--- a/modules/platen/_docs/markup/details/index.md
+++ b/modules/platen/_docs/markup/details/index.md
@@ -15,6 +15,9 @@ Memo:
         publish:    /frontmatter/platen/content/snippets/details/codeblock.json
       - merge:      frontmatter/codeblock.json
         publish:    /frontmatter/platen/content/snippets/details.json
+      - merge:
+          - frontmatter/codeblock.json
+        publish: /frontmatter/platen/markup/details.json
   Kind: Renderer.Codeblock
   Attributes:
     summary:

--- a/modules/platen/_docs/markup/itch/frontmatter/preset.json
+++ b/modules/platen/_docs/markup/itch/frontmatter/preset.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://beta.frontmatter.codes/frontmatter.schema.json",
+  "frontMatter.data.types": [
+    {
+      "id": "platen-markup-itch-preset",
+      "schema": "/modules/platen/markup/itch:preset.schema.yaml"
+    }
+  ],
+  "frontMatter.data.folders": [
+    {
+      "id": "platen-markup-itch-presets",
+      "path": "[[workspace]]/data/platen/embeds/itch",
+      "singleEntry": true,
+      "type": "platen-markup-itch-preset"
+    }
+  ]
+}

--- a/modules/platen/_docs/markup/itch/index.md
+++ b/modules/platen/_docs/markup/itch/index.md
@@ -11,17 +11,26 @@ Memo:
   MungeTitle: false
   front_matter:
     configs:
+      - definition: frontmatter/preset.json
+        publish:    /frontmatter/platen/data/itch.json
+        resolve_schemas: true
       - definition: frontmatter/image.json
         publish:    /frontmatter/platen/content/snippets/itch/image.json
       - merge:      frontmatter/image.json
         publish:    /frontmatter/platen/content/snippets/itch.json
+      - merge:
+        - frontmatter/preset.json
+        - frontmatter/image.json
+        publish: /frontmatter/platen/markup/itch.json
+        resolve_schemas: true
   Kind: Renderer.Image
   Aliases: []
   Attributes:
-    id:
-      Ignore: true
     class:
       Ignore: true
+    preset:
+      Type: String
+      Required: false
     dark:
       Type: Boolean
       Required: false
@@ -69,10 +78,15 @@ don't have to remember how the embed URL is constructed or how to use an `<ifram
 ## Examples
 
 ```memo-example-renderer { title="Minimal Example" }
+This example embeds the itch widget for The Isle with the default options.
+<!--- Example Start -->
 ![itch:The Isle by Luke Geating](1637303)
 ```
 
 ```memo-example-renderer { title="Square Embed with Linkback" }
+This example ensures the itch embed for The Isle is formatted as a square and
+that clicking on the embed takes the visitor to the itch project page.
+<!--- Example Start -->
 ![itch:The Isle by Luke Geating](1637303)
 {
   square   = true
@@ -81,6 +95,9 @@ don't have to remember how the embed URL is constructed or how to use an `<ifram
 ```
 
 ```memo-example-renderer { title="Fully Custom Embed" }
+This example shows all of the available options for customizing an itch embed
+and uses them to ensure the theme matches the project.
+<!--- Example Start -->
 ![itch:UNCONQUERED by Monkey's Paw Games](1765719)
 {
   square           = false
@@ -91,6 +108,20 @@ don't have to remember how the embed URL is constructed or how to use an `<ifram
   button_color     = "#e53b44"
   border_color     = "#fa5059"
   border_width     = 3
+}
+```
+
+```memo-example-renderer { title="Referencing preset" }
+This example uses a [preset](#presets) ID instead of the itch project ID to
+pull the settings from data. It specifies the project ID as an attribute
+because that value isn't defined in the preset. It overrides the values for
+[`square`](#square) and [`border_width`](#border_width) but inherits the rest.
+<!--- Example Start -->
+![itch:](UNCONQUERED)
+{
+  #1765719
+  square=true
+  border_width=5
 }
 ```
 
@@ -119,6 +150,11 @@ someone else, you may want to include that information too.
 Don't use any markup for this value. The text is added to an HTML attribute, not rendered from
 Markdown.
 
+If you're using a [preset](#presets) that defines the `title`, you can omit this value except for
+the prefix. For example, `![itch:](MyGame)` would be recognized as an itch embed but `![](MyGame)`
+would not. If neither the image link nor the referenced preset define a title, Platen raises an
+error.
+
 {{< memo/renderer/input "alt_text" >}}
 
 ### `source` (as `id`)
@@ -134,9 +170,19 @@ list of links at the very bottom of the page. That causes a popup to appear for 
 In the first line of the copyable HTML, you should see an attribute like
 `src="https://itch.io/embed/<id>"`. The number at the end of that URL is your project's ID.
 
+Instead of specifying an itch project ID, you can specify the ID for a preset defined in your site
+data folder. For more information, see [Presets](#presets).
+
 {{< memo/renderer/input "source" >}}
 
 ## Attributes
+
+### `id`
+
+Specifies the itch project ID for the embed. This is an alternative to specifying it as the `source`
+in the image link. It's only required when using a [preset](#presets) that doesn't define the `id`.
+
+{{< memo/renderer/attribute "id" >}}
 
 ### `dark`
 
@@ -195,7 +241,41 @@ inclusive. When this value is `0`, no border is displayed.
 
 {{< memo/renderer/attribute "border_width" >}}
 
+## Presets
+
+To make it easier to reuse your itch embeds, you can define any number of presets in your site data.
+They use the same keys as the attributes.
+
+To add a preset, create a YAML file in your site's [Data Folder][02] as
+`platen/embeds/itch/<ID>.yaml`. For example, if your site uses the default data directory, to create
+a preset for UNCONQUERED you would create the file `data/platen/embeds/itch/UNCONQUERED.yaml`.
+
+```yaml
+# data/platen/embeds/itch/UNCONQUERED.yaml
+id:               1765719
+title:            UNCONQUERED by Monkey's Paw Games
+linkback:         true
+background_color: "#d3d3ac"
+text_color:       "#000000"
+button_color:     "#e53b44"
+border_color:     "#fa5059"
+border_width:     3
+```
+
+You can reference a preset by specifying the preset's file name (without the `.yaml` suffix) as the
+ID in the image link, like `![itch:](UNCONQUERED)`.
+
+```details { summary="Warning" .warning }
+Make sure you specify the itch project id in the preset or as an attribute. If
+you don't define it in one of those places, Platen raises an error.
+```
+
+You can override any value from the preset when you use it. If you specify a [`title`] in your image
+link, that value overwrites the one defined in the preset. Any attributes you specify also overwrite
+the values from the preset.
+
 <!-- Link References -->
 [01]: https://itch.io/docs/creators/widget
+[02]: https://gohugo.io/templates/data-templates/#the-data-folder
 [s01]: mdn.html.element:iframe
 [s02]: mdn.html.global_attribute:title

--- a/modules/platen/_docs/markup/itch/preset.schema.yaml
+++ b/modules/platen/_docs/markup/itch/preset.schema.yaml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+# Can't have $schema - breaks frontmatter. Intellisense only works in VS Code
+# with the YAML extension directive at the top.
+# $schema: https://json-schema.org/draft/2020-12/schema
+$id: /modules/platen/markup/itch/schemas/preset
+title: Itch Embed Preset
+description: >-
+  Specifies a defined preset for embedding an itch project's widget in your Platen site.
+
+  https://platen.io/modules/platen/markup/itch
+type: object
+properties:
+  id:
+    title: Itch Project ID
+    description: |
+      Specify the itch project ID.
+
+      https://platen.io/modules/platen/markup/itch#source-as-id
+    type: integer
+  title:
+    title: Title
+    description: >-
+      Specifies the title attribute for the embed's iframe.
+
+      https://platen.io/modules/platen/markup/itch#alt_text-as-title
+    type: string
+  dark:
+    title: Use Dark Theme
+    description: >-
+      Specifies that the embed widget should use itch's default dark theme.
+
+      https://platen.io/modules/platen/markup/itch#dark
+    type: boolean
+    default: false
+  square:
+    title: Display as Square
+    description: >-
+      Specifies that the embed widget should display as a square.
+
+      https://platen.io/modules/platen/markup/itch#square
+    type: boolean
+    default: false
+  linkback:
+    title: Add Linkback
+    description: >-
+      Specifies that clicking the embed widget should go to the project page.
+
+      https://platen.io/modules/platen/markup/itch#linkback
+    type: boolean
+    default: false
+  background_color:
+    title: Background Color
+    description: >-
+      Specifies the background color for the embed widget.
+
+      https://platen.io/modules/platen/markup/itch#background_color
+    type: string
+  text_color:
+    title: Text Color
+    description: >-
+      Specifies the text color for the embed widget.
+
+      https://platen.io/modules/platen/markup/itch#text_color
+    type: string
+  button_color:
+    title: Button Color
+    description: >-
+      Specifies the background color for the purchase button on the embed widget.
+
+      https://platen.io/modules/platen/markup/itch#button_color
+    type: string
+  border_color:
+    title: Background Color
+    description: >-
+      Specifies color of the border for the embed widget.
+
+      https://platen.io/modules/platen/markup/itch#border_color
+    type: string
+  border_width:
+    title: Border Width
+    description: >-
+      Specifies the width of the embed widget's border in pixels, from 0 to 5.
+
+      https://platen.io/modules/platen/markup/itch#border_width
+    type: integer
+    minimum: 0
+    maximum: 5

--- a/modules/platen/_docs/markup/katex/_index.md
+++ b/modules/platen/_docs/markup/katex/_index.md
@@ -15,6 +15,10 @@ Memo:
           - ./block:frontmatter/codeblock.json
           - ./inline:frontmatter/image.json
         publish: /frontmatter/platen/content/snippets/katex.json
+      - merge:
+          - ./block:frontmatter/codeblock.json
+          - ./inline:frontmatter/image.json
+        publish: /frontmatter/platen/markup/katex.json
 ---
 
 Platen supports using [KaTeX markup][01] to add mathematical and scientific formulas to your pages.

--- a/modules/platen/_docs/markup/mermaid/index.md
+++ b/modules/platen/_docs/markup/mermaid/index.md
@@ -15,6 +15,9 @@ Memo:
         publish:    /frontmatter/platen/content/snippets/mermaid/codeblock.json
       - merge:      frontmatter/codeblock.json
         publish:    /frontmatter/platen/content/snippets/mermaid.json
+      - merge:
+          - frontmatter/codeblock.json
+        publish: /frontmatter/platen/markup/mermaid.json
   Kind: Renderer.Codeblock
   Attributes:
     container:

--- a/modules/platen/_docs/markup/section/index.md
+++ b/modules/platen/_docs/markup/section/index.md
@@ -15,6 +15,9 @@ Memo:
         publish:    /frontmatter/platen/content/snippets/section/codeblock.json
       - merge:      frontmatter/codeblock.json
         publish:    /frontmatter/platen/content/snippets/section.json
+      - merge:
+          - frontmatter/codeblock.json
+        publish: /frontmatter/platen/markup/section.json
   Kind: Renderer.Codeblock
   Data:
     root:

--- a/modules/platen/_docs/markup/tabs/index.md
+++ b/modules/platen/_docs/markup/tabs/index.md
@@ -18,6 +18,10 @@ Memo:
           - frontmatter/codeblock-group.json
           - frontmatter/codeblock-entry.json
         publish: /frontmatter/platen/content/snippets/tabs.json
+      - merge:
+          - frontmatter/codeblock-group.json
+          - frontmatter/codeblock-entry.json
+        publish: /frontmatter/platen/markup/tabs.json
   MungeTitle: false
   Kind: Renderer.Codeblock
   Attributes:

--- a/modules/platen/layouts/partials/platen/markup/itch/image.html
+++ b/modules/platen/layouts/partials/platen/markup/itch/image.html
@@ -26,6 +26,8 @@
 {{- end -}}
 
 {{- if $hasPrefix -}}
+  {{/* Presets contain settings from site data */}}
+  {{- $preset     := dict -}}
   {{/* Retrieve attributes for block syntax image only */}}
   {{- $attributes := dict -}}
 
@@ -37,8 +39,25 @@
   {{- $height := 167 -}}
   {{- $width  := 552 -}}
 
+  {{/* Set base URL */}}
+  {{- $BaseUrl := "https://itch.io/embed" -}}
+  {{- $url     := ""                      -}}
+
   {{- with $destination -}}
-    {{- $url := printf "https://itch.io/embed/%s" $destination -}}
+    {{- if not (findRE `^\d+$` $destination) -}}
+      {{- warnf "Destination is a preset: '%s'" $destination -}}
+      {{- with index site.Data.platen.embeds.itch $destination -}}
+        {{- $preset = . -}}
+        {{- with $preset.id -}}
+          {{- $url = printf "%s/%v" $BaseUrl . -}}
+        {{- end -}}
+      {{- else -}}
+        {{- errorf "Unable to find preset '%s' in site data 'platen.embeds.itch' - is '%s.yaml' defined?" -}}
+      {{- end -}}
+    {{- else -}}
+      {{- warnf "Destination is an ID:  '%s'" $destination -}}
+      {{- $url = printf "%s/%s" $BaseUrl $destination -}}
+    {{- end -}}
 
     {{/*
       Handle the alt text. If it's provided, use as title for iframe. Otherwise, assume the use of a
@@ -47,7 +66,11 @@
     {{- with $alt -}}
       {{- $title = $alt -}}
     {{- else -}}
-      {{/* Assume preset, implement later */}}
+      {{- with $preset.title -}}
+        {{- $title = . -}}
+      {{- else -}}
+        {{- errorf "Missing title for itch embed; no title specified as alt text or in preset from site data (platen.embeds.itch.%s)." $destination -}}
+      {{- end -}}
       {{- warnf "Finding itchio preset %s" $destination -}}
     {{- end -}}
 
@@ -55,15 +78,33 @@
     {{/* Both should set the url and title */}}
     {{- if $IsBlock -}}
       {{- $attributes       = $Params.Attributes -}}
-      {{- $dark            := $attributes.dark            | default false -}}
-      {{- $square          := $attributes.square          | default false -}}
-      {{- $linkback        := $attributes.linkback        | default false -}}
-      {{- $backgroundColor := $attributes.background_color                -}}
-      {{- $textColor       := $attributes.text_color                      -}}
-      {{- $buttonColor     := $attributes.button_color                    -}}
-      {{- $borderColor     := $attributes.border_color                    -}}
-      {{- $borderWidth     := $attributes.border_width                    -}}
-      {{- $urlQueryParams  := slice                                       -}}
+      {{- $dark            := $attributes.dark
+                              | default $preset.dark
+                              | default false
+      -}}
+      {{- $square          := $attributes.square
+                              | default $preset.square
+                              | default false
+      -}}
+      {{- $linkback        := $attributes.linkback
+                              | default $preset.linkback
+                              | default false
+      -}}
+      {{- $backgroundColor := $attributes.background_color | default $preset.background_color -}}
+      {{- $textColor       := $attributes.text_color       | default $preset.text_color       -}}
+      {{- $buttonColor     := $attributes.button_color     | default $preset.button_color     -}}
+      {{- $borderColor     := $attributes.border_color     | default $preset.border_color     -}}
+      {{- $borderWidth     := $attributes.border_width     | default $preset.border_width     -}}
+      {{- $urlQueryParams  := slice                                                           -}}
+
+      {{/* In this case the usage specified a preset that didn't define an id */}}
+      {{- if eq $url "" -}}
+        {{- with $attributes.id -}}
+          {{- $url = printf "%s/%s" $BaseUrl . -}}
+        {{- else -}}
+          {{- errorf "No ID specified for itch embed. Used preset '%s', which doesn't define an id, without specifying an ID attribute." $destination -}}
+        {{- end -}}
+      {{- end -}}
 
       {{- if $linkback -}}
         {{- $urlQueryParams = $urlQueryParams | append "linkback=true" -}}


### PR DESCRIPTION
This change adds presets for the itch embed markup and lays the groundwork for schematized data files, supporting the initial preset in the Front Matter configuration export.

- Resolves #25 