### PR TITLE
(MAINT) Rework memo examples to be figures

### DIFF
--- a/modules/memo/layouts/partials/memo/renderers/example/renderer.html
+++ b/modules/memo/layouts/partials/memo/renderers/example/renderer.html
@@ -54,24 +54,36 @@
   {{- end -}}
 
   {{/* Render the input subsection */}}
-  {{- $inputHeading := printf "%s Markdown Input { #%s-markdown-input }" $subHeadingMarker $id -}}
-  {{- $inputHeading  = $page.RenderString $inputHeading                                        -}}
   {{- $inputContent :=  printf "%smarkdown\n%s\n%s" $fence $mungedCode $fence                  -}}
   {{- $inputContent  = $page.RenderString $inputContent                                        -}}
-  {{- $renderedCode  = printf "%s\n\n%s\n\n%s" $renderedCode $inputHeading $inputContent       -}}
+  {{- $renderedCode  = printf "%s\n  %s\n\n%s\n\n%s\n\n%s"
+                       $renderedCode
+                       (printf `<figure class="memo-example" id="%s-markdown-input" open>` $id)
+                        "  <figcaption>Markdown Input</figcaption>"
+                       $inputContent
+                       "</figure>"
+  -}}
 
   {{/* Render the HTML output subsection */}}
-  {{- $htmlHeading := printf "%s HTML Output { #%s-html-output }" $subHeadingMarker $id -}}
-  {{- $htmlHeading  = $page.RenderString $htmlHeading                                   -}}
   {{- $htmlContent := printf "``````html\n%s\n``````" ($page.RenderString $mungedCode)  -}}
   {{- $htmlContent  = $page.RenderString $htmlContent                                   -}}
-  {{- $renderedCode = printf "%s\n\n%s\n\n%s" $renderedCode $htmlHeading $htmlContent   -}}
+  {{- $renderedCode = printf "%s\n  %s\n\n%s\n\n%s\n\n%s"
+                       $renderedCode
+                       (printf `<figure class="memo-example" id="%s-html-output" open>` $id)
+                        "  <figcaption>HTML Output</figcaption>"
+                       $htmlContent
+                       "</figure>"
+  -}}
 
   {{/* Render the actual output subsection */}}
-  {{- $renderHeading := printf "%s Rendered Output { #%s-rendered-output }" $subHeadingMarker $id -}}
-  {{- $renderHeading  = $page.RenderString $renderHeading                                         -}}
   {{- $renderContent := $page.RenderString $mungedCode                                            -}}
-  {{- $renderedCode   = printf "%s\n\n%s\n\n%s" $renderedCode $renderHeading $renderContent       -}}
+  {{- $renderedCode = printf "%s\n  %s\n\n%s\n\n%s\n\n%s"
+                       $renderedCode
+                       (printf `<figure class="memo-example" id="%s-rendered-output" open>` $id)
+                        "  <figcaption>Rendered Output</figcaption>"
+                       $renderContent
+                       "</figure>"
+  -}}
 {{- end -}}
 
 {{- return $renderedCode -}}

--- a/modules/memo/layouts/partials/memo/renderers/example/shortcode.html
+++ b/modules/memo/layouts/partials/memo/renderers/example/shortcode.html
@@ -40,23 +40,35 @@
   {{- $mungedCode := partial "memo/utils/shortcode/getUncommented" $code   -}}
 
   {{/* Render the input subsection */}}
-  {{- $inputHeading := printf "%s Markdown Input { #%s-markdown-input }" $subHeadingMarker $id -}}
-  {{- $inputHeading  = $page.RenderString $inputHeading                                        -}}
   {{- $inputContent := highlight $mungedCode       "go"                                        -}}
-  {{- $renderedCode  = printf "%s\n\n%s\n\n%s" $renderedCode $inputHeading $inputContent       -}}
+  {{- $renderedCode  = printf "%s\n  %s\n\n%s\n\n%s\n\n%s"
+                       $renderedCode
+                       (printf `<figure class="memo-example" id="%s-markdown-input" open>` $id)
+                        "  <figcaption>Markdown Input</figcaption>"
+                       $inputContent
+                       "</figure>"
+  -}}
 
   {{/* Render the HTML output subsection */}}
-  {{- $htmlHeading := printf "%s HTML Output { #%s-html-output }" $subHeadingMarker $id -}}
-  {{- $htmlHeading  = $page.RenderString $htmlHeading                                   -}}
   {{- $htmlContent := $page.RenderString $mungedCode                                    -}}
   {{- $htmlContent  = highlight $htmlContent "html"                                     -}}
-  {{- $renderedCode = printf "%s\n\n%s\n\n%s" $renderedCode $htmlHeading $htmlContent   -}}
+  {{- $renderedCode = printf "%s\n  %s\n\n%s\n\n%s\n\n%s"
+                       $renderedCode
+                       (printf `<figure class="memo-example" id="%s-html-output" open>` $id)
+                        "  <figcaption>HTML Output</figcaption>"
+                       $htmlContent
+                       "</figure>"
+  -}}
 
   {{/* Render the actual output subsection */}}
-  {{- $renderHeading := printf "%s Rendered Output { #%s-rendered-output }" $subHeadingMarker $id -}}
-  {{- $renderHeading  = $page.RenderString $renderHeading                                         -}}
   {{- $renderContent := $page.RenderString $mungedCode                                            -}}
-  {{- $renderedCode   = printf "%s\n\n%s\n\n%s" $renderedCode $renderHeading $renderContent       -}}
+  {{- $renderedCode = printf "%s\n  %s\n\n%s\n\n%s\n\n%s"
+                       $renderedCode
+                       (printf `<figure class="memo-example" id="%s-rendered-output" open>` $id)
+                        "  <figcaption>Rendered Output</figcaption>"
+                       $renderContent
+                       "</figure>"
+  -}}
 {{- end -}}
 
 {{- return $renderedCode -}}


### PR DESCRIPTION
This change converts the rendering for examples from the memo module to write the code representations in figures with captions instead of as sections under a heading.

This makes for a shorter TOC while keeping the examples linkable, as each figure is given a unique ID matching the previous heading.