### PR TITLE
(MAINT) Fix no-logo behavior

### DIFF
--- a/data/_params/platen/display.yaml
+++ b/data/_params/platen/display.yaml
@@ -2,9 +2,9 @@
 table_of_contents:
   minimum_level: 1
   maximum_level: 6
-date_format: "January 2, 2006"             # BookDateFormat
+date_format: "January 2, 2006"
 menu:
-  root_section: /                          # BookSection
+  root_section: /
   before_injection:
     entries:
       - feature: toroidal
@@ -12,4 +12,4 @@ menu:
         page_path: sites/platen
         display_name: Platen Sites
 logo:
-  url: /images/logo.svg   
+  url: /images/logo.svg

--- a/modules/platen/_schema_data/schemas/platen/site/display/settings.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/display/settings.yaml
@@ -78,7 +78,7 @@ properties:
     properties:
       url:
         title: Logo URL
-        description: Choose whether to use Hugo's builtin table of contents.
+        description: Specifies the path to the logo to use for the site's branding.
         schematize:
           details: |
             Defines the path to the logo file. You can specify the path to an image in the `assets`
@@ -90,11 +90,9 @@ properties:
             folder for ease-of-use. We don't recommend you use a remote image for your site's logo
             due to site performance impacts.
 
-            This value defaults to `/images/logo.svg`, which you can place in the `static` or
-            `assets` folder for your site.
+            This value isn't set by default.
           weight: 1
         type: string
-        default: /images/logo.svg
   menu:
     $ref: ./menu/settings.yaml
     schematize:

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -160,8 +160,6 @@ platen:
     header:
       title_as_heading: false
     menu_root_section: /                        # BookSection
-    logo:
-      url: /images/logo.svg                   # BookLogo
   features:
     search:                                   # booksearch
       enabled: true

--- a/modules/platen/layouts/partials/platen/menu/brand.html
+++ b/modules/platen/layouts/partials/platen/menu/brand.html
@@ -1,12 +1,12 @@
 {{- $Context    := .                                                                -}}
 {{- $ConfigKey  := "platen.display.logo.url"                                        -}}
-{{- $LogoUrl    := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
+{{- $LogoUrl    := partialCached "platen/param/getKey" $ConfigKey $ConfigKey        -}}
 {{- $NoHomeFile := not site.Home.File                                               -}}
 <h2 class="platen-brand">
   <a class="flex align-center"
      href="{{ cond $NoHomeFile $Context.Sites.First.Home.RelPermalink site.Home.RelPermalink }}">
     {{- with $LogoUrl -}}
-    <img src="{{ $LogoUrl | relURL }}" alt="Logo" />
+      <img src="{{ $LogoUrl | relURL }}" alt="Logo" />
     {{- end -}}
     <span>{{ site.Title }}</span>
   </a>


### PR DESCRIPTION
Prior to this change, you could not actually prevent Platen from using the logo in the site configuration. This change removes the default value, making it fall back to an empty string which is ignored.