### PR TITLE
(MAINT) Use snake case for schematize props

### DIFF
--- a/data/schemas/build.yaml
+++ b/data/schemas/build.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/build.schema.yaml
 title: Hugo Build Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/build.yaml

--- a/data/schemas/config.yaml
+++ b/data/schemas/config.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/config.schema.yaml
 title: Hugo Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/config.yaml
@@ -11,7 +11,7 @@ properties:
   params:
     type: object
     schematize:
-      noMungeDescription: true
+      no_munge_description: true
     properties:
       platen:
         $ref: ./platen/site/config.yaml

--- a/data/schemas/frontmatter.yaml
+++ b/data/schemas/frontmatter.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/frontmatter.schema.yaml
 title: Hugo Front Matter Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/frontmatter.yaml

--- a/data/schemas/hugo/config.yaml
+++ b/data/schemas/hugo/config.yaml
@@ -5,7 +5,7 @@ description: |-
   Hugo's configuration file.
   https://gohugo.io/getting-started/configuration/
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 properties:
   archetypeDir:

--- a/data/schemas/hugo/definitions/cascade.yaml
+++ b/data/schemas/hugo/definitions/cascade.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/definitions/cascade.yaml
 title: Cascade Options
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 properties:
   aliases:

--- a/data/schemas/hugo/definitions/hugoFolder.yaml
+++ b/data/schemas/hugo/definitions/hugoFolder.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/definitions/hugoVersion.yaml
 title: Hugo Version
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 oneOf:
   - type: string
     minLength: 1

--- a/data/schemas/hugo/definitions/hugoVersion.yaml
+++ b/data/schemas/hugo/definitions/hugoVersion.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/definitions/hugoVersion.yaml
 title: Hugo Version
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: string
 enum:
   - 0.109.0

--- a/data/schemas/hugo/definitions/module/mounts.yaml
+++ b/data/schemas/hugo/definitions/module/mounts.yaml
@@ -7,7 +7,7 @@ description: |-
   https://gohugo.io/hugo-modules/configuration/#module-config-mounts
 type: array
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 items:
   type: object
   default:

--- a/data/schemas/hugo/definitions/outputFormats.yaml
+++ b/data/schemas/hugo/definitions/outputFormats.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/definitions/outputFormats.yaml
 title: Output Formats
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 patternProperties:
   ".":

--- a/data/schemas/hugo/definitions/uniqueStringArray.yaml
+++ b/data/schemas/hugo/definitions/uniqueStringArray.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/definitions/uniqueStringArray.yaml
 title: Unique String Array
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: array
 uniqueItems: true
 items:

--- a/data/schemas/hugo/page.yaml
+++ b/data/schemas/hugo/page.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/content/frontmatter.yaml
 title: Frontmatter Options
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 properties:
   aliases:

--- a/data/schemas/hugo/properties/build.yaml
+++ b/data/schemas/hugo/properties/build.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/sitemap.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Build Options
 description: |-
   The build options

--- a/data/schemas/hugo/properties/frontmatter.yaml
+++ b/data/schemas/hugo/properties/frontmatter.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/frontmatter.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Front Matter Options
 description: |-
   The front matter options

--- a/data/schemas/hugo/properties/imaging.yaml
+++ b/data/schemas/hugo/properties/imaging.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/imaging.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Image Processing Options
 description: |-
   The image processing options

--- a/data/schemas/hugo/properties/languages.yaml
+++ b/data/schemas/hugo/properties/languages.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/languages.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Language Options
 description: |-
   The language options

--- a/data/schemas/hugo/properties/markup.yaml
+++ b/data/schemas/hugo/properties/markup.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/markup.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Markdown Options
 description: |-
   The markdown options

--- a/data/schemas/hugo/properties/mediaTypes.yaml
+++ b/data/schemas/hugo/properties/mediaTypes.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/mediaTypes.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Media Type's Options
 description: |-
   The media type's options

--- a/data/schemas/hugo/properties/menu.yaml
+++ b/data/schemas/hugo/properties/menu.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/menu.yaml
 title: Media Menu Options
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 description: |-
   The menu options
   https://gohugo.io/content-management/menus/#add-non-content-entries-to-a-menu

--- a/data/schemas/hugo/properties/minify.yaml
+++ b/data/schemas/hugo/properties/minify.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/minify.yaml
 title: Minify Options
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 description: |2-
   Configures minify options.
   https://gohugo.io/getting-started/configuration/#configure-minify

--- a/data/schemas/hugo/properties/module.yaml
+++ b/data/schemas/hugo/properties/module.yaml
@@ -7,7 +7,7 @@ description: |-
   https://gohugo.io/hugo-modules/configuration/
 type: object
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 default:
   noProxy: none
   noVendor: ""

--- a/data/schemas/hugo/properties/privacy.yaml
+++ b/data/schemas/hugo/properties/privacy.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/privacy.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Privacy Options
 description: |-
   Configuration for complying with GDPR.

--- a/data/schemas/hugo/properties/related.yaml
+++ b/data/schemas/hugo/properties/related.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/related.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Related Content Options
 description: |-
   The related content options

--- a/data/schemas/hugo/properties/security.yaml
+++ b/data/schemas/hugo/properties/security.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/security.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Security Options
 description: |-
   The security options

--- a/data/schemas/hugo/properties/sitemap.yaml
+++ b/data/schemas/hugo/properties/sitemap.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/sitemap.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Sitemap Options
 description: |-
   The sitemap options

--- a/data/schemas/hugo/properties/taxonomies.yaml
+++ b/data/schemas/hugo/properties/taxonomies.yaml
@@ -2,7 +2,7 @@
 $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/hugo/properties/taxonomies.yaml
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 title: Taxonomy Options
 description: |-
   The taxonomy options

--- a/data/schemas/imaging.yaml
+++ b/data/schemas/imaging.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/imaging.schema.yaml
 title: Hugo Imaging Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/imaging.yaml

--- a/data/schemas/languages.yaml
+++ b/data/schemas/languages.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/languages.schema.yaml
 title: Hugo Languages Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/languages.yaml

--- a/data/schemas/markup.yaml
+++ b/data/schemas/markup.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/markup.schema.yaml
 title: Hugo Markup Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/markup.yaml

--- a/data/schemas/mediaTypes.yaml
+++ b/data/schemas/mediaTypes.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/mediaTypes.schema.yaml
 title: Hugo Media Types Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/mediaTypes.yaml

--- a/data/schemas/menu.yaml
+++ b/data/schemas/menu.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/menu.schema.yaml
 title: Hugo Menu Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/menu.yaml

--- a/data/schemas/minify.yaml
+++ b/data/schemas/minify.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/minify.schema.yaml
 title: Hugo Minify Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/minify.yaml

--- a/data/schemas/module.yaml
+++ b/data/schemas/module.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/module.schema.yaml
 title: Hugo Module Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/module.yaml

--- a/data/schemas/page.yaml
+++ b/data/schemas/page.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/page.schema.yaml
 title: Page Front Matter
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/page.yaml

--- a/data/schemas/params.yaml
+++ b/data/schemas/params.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/params.schema.yaml
 title: Hugo Params Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 # anyOf:
 #   - $ref: ./hugo/config.yaml

--- a/data/schemas/post.yaml
+++ b/data/schemas/post.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/post.schema.yaml
 title: Post Front Matter
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/page.yaml

--- a/data/schemas/privacy.yaml
+++ b/data/schemas/privacy.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/privacy.schema.yaml
 title: Hugo Privacy Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/privacy.yaml

--- a/data/schemas/related.yaml
+++ b/data/schemas/related.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/related.schema.yaml
 title: Hugo Related Content Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/related.yaml

--- a/data/schemas/section.yaml
+++ b/data/schemas/section.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/section.schema.yaml
 title: Page Front Matter
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/page.yaml

--- a/data/schemas/security.yaml
+++ b/data/schemas/security.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/security.schema.yaml
 title: Hugo Security Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/security.yaml

--- a/data/schemas/sitemap.yaml
+++ b/data/schemas/sitemap.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/sitemap.schema.yaml
 title: Hugo Site Map Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/sitemap.yaml

--- a/data/schemas/taxonomies.yaml
+++ b/data/schemas/taxonomies.yaml
@@ -3,7 +3,7 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: /schemas/taxonomies.schema.yaml
 title: Hugo Taxonomies Configuration
 schematize:
-  noMungeDescription: true
+  no_munge_description: true
 type: object
 anyOf:
   - $ref: ./hugo/properties/taxonomies.yaml

--- a/modules/platen/_schema_data/schemas/platen/site/theme/variables/basic_scss.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/theme/variables/basic_scss.yaml
@@ -389,7 +389,7 @@ properties:
           https://developer.mozilla.org/en-US/docs/Web/CSS/color_value
         schematize:
           href: pattern-any
-          noMungeDescription: true
+          no_munge_description: true
           details: |
             Specify a valid color. For more info, see [sref:`<color>`].
 

--- a/modules/schematize/layouts/partials/schematize/item.schematize.json
+++ b/modules/schematize/layouts/partials/schematize/item.schematize.json
@@ -9,7 +9,7 @@
   {{- $schemaData = index $schemaData $level -}}
 {{- end -}}
 {{/* Munge descriptions to link to their docs unless munging isn't desired. */}}
-{{- if not $schemaData.schematize.noMungeDescription -}}
+{{- if not $schemaData.schematize.no_munge_description -}}
   {{- $docsURL     := ($context.OutputFormats.Get "html").Permalink                    -}}
   {{- $mungeParams := dict "schemaData" $schemaData "docsURL" $docsURL                 -}}
   {{- $schemaData   = partial "schematize/utils/schema/munge/description" $mungeParams -}}

--- a/modules/schematize/layouts/partials/schematize/utils/schema/munge/description.html
+++ b/modules/schematize/layouts/partials/schematize/utils/schema/munge/description.html
@@ -44,9 +44,11 @@
     {{- $description := printf "%s\n\n%s%s" $schemaData.description $docsURL $postfix -}}
     {{- $schemaData = merge $schemaData (dict "description" $description) -}}
   {{- else if reflect.IsMap $value -}}
-    {{- $recursiveParams := dict "schemaData" $value "docsURL" $docsURL "postfix" $key "hrefPrefix" $prefix -}}
-    {{- $munged := partial "schematize/utils/schema/munge/description" $recursiveParams -}}
-    {{- $schemaData = merge $schemaData (dict $key $munged) -}}
+    {{- if not $value.schematize.no_munge_description -}}
+      {{- $recursiveParams := dict "schemaData" $value "docsURL" $docsURL "postfix" $key "hrefPrefix" $prefix -}}
+      {{- $munged := partial "schematize/utils/schema/munge/description" $recursiveParams -}}
+      {{- $schemaData = merge $schemaData (dict $key $munged) -}}
+    {{- end -}}
   {{- else if reflect.IsSlice $value -}}
     {{- $munged := slice -}}
     {{- range $item := $value -}}


### PR DESCRIPTION
This change replaces `noMungeDescription` in schematize with the snake-cased `no_munge_description` instead. This keeps our principle of using snake case for author-facing options.