### PR TITLE
(GH-66) Add Sharing feature

### DIFF
--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -174,6 +174,60 @@ platen:
         header: platen/features/pwa/header
     portable_links:                            # BookPortableLinks
       enabled: true
+    sharing:
+      enabled: true
+      partials:
+        menu:  platen/features/sharing/menu/render
+      menu_text: Share to...
+      options:
+        blogger:
+          href_prefix: https://www.blogger.com/blog-this.g
+          text_key: t
+          url_key: u
+        evernote:
+          href_prefix: https://www.evernote.com/clip.action
+          text_key: title
+          url_key: url
+        facebook:
+          href_prefix: https://www.facebook.com/sharer/sharer.php
+          text_key: quote
+          url_key: u
+          by_default: true
+        hackernews:
+          href_prefix: https://news.ycombinator.com/submitlink
+          text_key: t
+          url_key: u
+        linkedin:
+          href_prefix: https://www.linkedin.com/sharing/share-offsite/
+          text_key: UNSUPPORTED
+          url_key: url
+        livejournal:
+          href_prefix: http://www.livejournal.com/update.bml
+          text_key: subject
+          url_key: event
+        pinterest:
+          href_prefix: https://pinterest.com/pin/create/button/
+          text_key: description
+          url_key: url
+        reddit:
+          href_prefix: https://www.reddit.com/submit?
+          text_key: title
+          url_key: url
+          by_default: true
+        telegram:
+          href_prefix: https://t.me/share/url
+          text_key: text
+          url_key: url
+        tumblr:
+          href_prefix: https://www.tumblr.com/widgets/share/tool
+          text_key: caption
+          url_key: canonicalUrl
+          by_default: true
+        twitter:
+          href_prefix: https://twitter.com/intent/tweet
+          text_key: text
+          url_key: url
+          by_default: true
   markup:
     art:
       enabled: true
@@ -204,6 +258,19 @@ platen:
         renderers:
           codeblock: platen/markup/details/codeblock
       style: details
+    # icons:
+    #   enabled: true
+    #   partials:
+    #     header: platen/markup/header/icons
+    #     renderers:
+    #       image: platen/markup/icons/image
+    #   sources:
+    #     font_awesome:
+    #       enabled: true
+    #       partials:
+    #         header: platen/markup/icons/fa/header
+    #         renderers:
+    #           image: platen/markup/icons/fa/image
     itch:
       enabled: true
       partials:

--- a/modules/platen/layouts/partials/platen/features/sharing/menu/definedOptions.html
+++ b/modules/platen/layouts/partials/platen/features/sharing/menu/definedOptions.html
@@ -1,0 +1,13 @@
+{{/*
+    This partial returns a slice of the names for the defined social sharing
+    options. This makes it easier to check if a specified option exists.
+*/}}
+{{- $ConfigKey := "platen.features.sharing"                                 -}}
+{{- $Config    := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
+
+{{- $definedOptions := slice -}}
+{{- range $Option, $_ := $Config.options -}}
+  {{- $definedOptions = $definedOptions | append $Option -}}
+{{- end -}}
+
+{{- return $definedOptions -}}

--- a/modules/platen/layouts/partials/platen/features/sharing/menu/entry.html
+++ b/modules/platen/layouts/partials/platen/features/sharing/menu/entry.html
@@ -1,0 +1,45 @@
+{{- $Input          := .                                                              -}}
+{{- $Context        := $Input.Context                                                 -}}
+{{- $Options        := $Input.Options                                                 -}}
+{{- $ConfigKey      := "platen.features.sharing"                                      -}}
+{{- $Config         := partialCached "platen/param/getKey" $ConfigKey $ConfigKey      -}}
+{{- $PreviewText    := $Context.Params.platen.sharing.text | default $Context.Summary -}}
+
+{{/*  Handle when the entry options are a map or just the option name as a string  */}}
+{{- $OptionName := "" -}}
+{{- $EntryTitle := "" -}}
+{{- if reflect.IsMap $Options -}}
+  {{- $OptionName = $Options.name  -}}
+  {{- $EntryTitle = $Options.title -}}
+{{- else -}}
+  {{- $OptionName = $Options -}}
+{{- end -}}
+
+{{- $renderString := "" -}}
+
+{{- with (index $Config.options $OptionName) -}}
+  {{- $Option      := .                   -}}
+  {{- $url         := $Option.href_prefix -}}
+  {{- $OptionTitle := $EntryTitle
+                      | default $Option.title
+                      | default (title $OptionName)
+                      | $Context.Page.RenderString
+  -}}
+
+  {{/*  Handle query params  */}}
+  {{- $queryParams := slice -}}
+  {{- with $Option.text_key -}}
+    {{- $queryParams = $queryParams | append . | append $PreviewText -}}
+  {{- end -}}
+  {{- with $Option.url_key -}}
+    {{- $queryParams = $queryParams | append . | append $Context.Permalink -}}
+  {{- end -}}
+
+  {{/*  Build the url, then anchor, and finally place inside list item  */}}
+  {{- $queryParams  = querify $queryParams | safeURL                        -}}
+  {{- $url          = printf  "%s?%s" $url $queryParams | safeURL           -}}
+  {{- $anchor      := printf  `      <a href="%s">%s</a>` $url $OptionTitle -}}
+  {{- $renderString = delimit (slice "    <li>" $anchor "    </li>") "\n"   -}}
+{{- end -}}
+
+{{- return $renderString -}}

--- a/modules/platen/layouts/partials/platen/features/sharing/menu/render.html
+++ b/modules/platen/layouts/partials/platen/features/sharing/menu/render.html
@@ -1,0 +1,90 @@
+{{- $Context        := .Context                                                          -}}
+{{- $Entry          := .entry                                                            -}}
+{{- $MenuCollapse   := $Entry.collapse                                                   -}}
+{{- $menuFlatten    := $Entry.flatten                                                    -}}
+{{- $class          := $Entry.class                                                      -}}
+{{- $ConfigKey      := "platen.features.sharing"                                         -}}
+{{- $Config         := partialCached "platen/param/getKey" $ConfigKey $ConfigKey         -}}
+{{- $DefinedOptions := partialCached "platen/features/sharing/menu/definedOptions" "" "" -}}
+{{- $EntryText      := $Entry.text | default $Config.menu_text                           -}}
+
+{{/*  Handle menu options  */}}
+{{- if and $menuFlatten $MenuCollapse -}}
+  {{- warnf "Specified both flatten and collapse for sharing entry in site menu. Preferring collapse instead." -}}
+  {{- $menuFlatten = false -}}
+{{- end -}}
+
+{{/*  The flatten and collapse options change how the entries appear in the site menu  */}}
+{{- if $menuFlatten -}}
+  {{- with $class -}}
+    {{- $class = " %s" $class -}}
+  {{- end -}}
+  {{- $class = printf `class="platen-section-flat%s"` $class -}}
+{{- else -}}
+  {{- with $class -}}
+    {{- $class = printf `class="%s"` $class -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+    Initialize the slices for entries. menuEntries holds the rendered entries,
+    weightedList and unweightedList hold their respective entry definitions.
+
+    This is needed so we can render weighted entries in order, then unweighted
+    entries.
+*/}}
+{{- $menuEntries    := slice -}}
+{{- $weightedList   := slice -}}
+{{- $unweightedList := slice -}}
+
+{{- with $Entry.options -}}
+  {{ range $option := . -}}
+    {{- if and (not (reflect.IsMap $option)) (in $DefinedOptions $option) -}}
+      {{- $unweightedList = $unweightedList | append $option -}}
+    {{- else if (in $DefinedOptions $option.name) -}}
+      {{- $weightedList = $weightedList | append $option -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- range $Platform, $Settings := $Config.options -}}
+    {{- if eq true $Settings.by_default -}}
+      {{- $unweightedList = $unweightedList | append $Platform -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- range $Item := sort $weightedList "weight" -}}
+  {{- $Input      := dict "Context" $Context "Options" $Item             -}}
+  {{- $menuEntry  := partial "platen/features/sharing/menu/entry" $Input -}}
+  {{- $menuEntries = $menuEntries | append $menuEntry                    -}}
+{{- end -}}
+
+{{- range $Item := sort $unweightedList -}}
+  {{- $Input      := dict "Context" $Context "Options" $Item             -}}
+  {{- $menuEntry  := partial "platen/features/sharing/menu/entry" $Input -}}
+  {{- $menuEntries = $menuEntries | append $menuEntry                    -}}
+{{- end -}}
+
+{{- $renderStrings := slice -}}
+{{- if $menuFlatten -}}
+  {{- $renderStrings = $renderStrings | append (printf "<li %s>" ($class | safeHTMLAttr)) -}}
+  {{- $renderStrings = $renderStrings | append (printf "  <span>%s</span>" $EntryText)    -}}
+{{- else if $MenuCollapse -}}
+  {{- $id := printf "section-%s" (md5 $EntryText) -}}
+  {{- $renderStrings = $renderStrings | append (printf `<li %s>` ($class | safeHTMLAttr))                       -}}
+  {{- $renderStrings = $renderStrings | append (printf `  <input type="checkbox" id="%s" class="toggle">`  $id) -}}
+  {{- $renderStrings = $renderStrings | append (printf `  <label for="%s" class="flex justify-between" />` $id) -}}
+  {{- $renderStrings = $renderStrings | append (printf `    <a role="button">%s</a>` $EntryText)                -}}
+  {{- $renderStrings = $renderStrings | append ("  </label>")                                                   -}}
+{{- else -}}
+  {{- $renderStrings = $renderStrings | append (printf `<li %s>` ($class | safeHTMLAttr)) -}}
+  {{- $renderStrings = $renderStrings | append (printf `  <span>%s</span>` $EntryText)    -}}
+{{- end -}}
+{{- $renderStrings = $renderStrings | append "  <ul>" -}}
+{{- range $MenuEntry := $menuEntries -}}
+  {{- $renderStrings = $renderStrings | append $MenuEntry -}}
+{{- end -}}
+{{- $renderStrings = $renderStrings | append "  </ul>" -}}
+
+{{/*  Render the menu entries  */}}
+{{- delimit $renderStrings "\n" | safeHTML -}}


### PR DESCRIPTION
This change adds the sharing feature to Platen, making it easier to share a page to various social media sites or with communication platforms.

This change adds:

- [x] A menu feature option for including share links in the site menu
- [ ] A footer option for including share links in page footers
- [ ] A sharing markup for including a share link anywhere on a page
- [ ] A ToC feature option for including share links in the Table of Contents

To Do:

- [ ] Documentation
- [ ] Front Matter