### PR TITLE
(MAINT) Fix site search

### DIFF
--- a/modules/platen/assets/scripts/features/search/data.json
+++ b/modules/platen/assets/scripts/features/search/data.json
@@ -1,8 +1,7 @@
+{{- $pages := where site.Pages "Kind" "in" (slice "page" "section")      -}}
+{{- $pages  = where $pages "Params.platen.exclude_from_search" "!=" true -}}
+{{- $pages  = where $pages "Content" "!=" ""                             -}}
 [
-{{- $pages := where site.Pages "Kind" "in" (slice "page" "section") -}}
-{{- $pages = where $pages "Params.platen.exclude_from_search" "!=" true -}}
-{{- $pages = where $pages "Content" "not in" (slice nil "") -}}
-
 {{ range $index, $page := $pages }}
 {{ if gt $index 0}},{{end}} {
     "id": {{ $index }},

--- a/modules/platen/assets/scripts/features/search/index.js
+++ b/modules/platen/assets/scripts/features/search/index.js
@@ -1,12 +1,11 @@
+{{- $Context      := .              -}}
+{{- $DataUrl      := .SearchDataUrl -}}
+{{- $Config       := .SearchConfig  -}}
 'use strict';
 
-{{ $searchDataFile := printf "%s.search-data.json" .Language.Lang }}
-{{ $searchData := resources.Get "scripts/features/search/data.json" | resources.ExecuteAsTemplate $searchDataFile . | resources.Minify | resources.Fingerprint }}
-{{ $searchConfig := i18n "PlatenSearchConfig" | default "{}" }}
-
 (function () {
-  const searchDataURL = '{{ $searchData.RelPermalink }}';
-  const indexConfig = Object.assign({{ $searchConfig }}, {
+  const searchDataURL = '{{ $DataUrl }}';
+  const indexConfig = Object.assign({{ $Config }}, {
     doc: {
       id: 'id',
       field: ['title', 'content'],

--- a/modules/platen/layouts/partials/platen/features/search/header.html
+++ b/modules/platen/layouts/partials/platen/features/search/header.html
@@ -1,8 +1,21 @@
 {{- $Context          := .                                            -}}
 {{- $IntegrityPartial := "platen/utils/getIntegrityAttributes"        -}}
+
+{{- $searchDataFile := printf "%s.search-data.json" .Language.Lang }}
+{{- $searchData     := resources.Get "scripts/features/search/data.json"
+                      | resources.ExecuteAsTemplate $searchDataFile .
+                      | resources.Minify
+                      | resources.Fingerprint
+-}}
+{{- $searchConfig    := i18n "PlatenSearchConfig" | default "{}" }}
+{{- $ContextSearchJS := dict "SearchDataUrl" $searchData.RelPermalink
+                            "SearchConfig"  $searchConfig
+-}}
+{{- $MakeItPub := $searchData.Publish -}}
+
 {{- $searchJSFile     := printf "%s.search.js" $Context.Language.Lang -}}
 {{- $searchJS         := resources.Get "scripts/features/search/index.js"
-                         | resources.ExecuteAsTemplate $searchJSFile $Context
+                         | resources.ExecuteAsTemplate $searchJSFile $ContextSearchJS
                          | resources.Fingerprint
 }}
 {{- $searchJSIntegrity := partialCached $IntegrityPartial $searchJS "SearchJS" -}}


### PR DESCRIPTION
Prior to this change, site search was broken. The data file was empty and not always built. This change ensures that:

1. The data file actually contains the expected entries
2. The calling (and publishing) of the data template is predictable and happens in the heading template.
3. The JS file is simplified to use passed values instead of building the template inside itself.