### PR TITLE
(MAINT) Support details markup as collapsible sections

### DIFF
--- a/modules/platen/_docs/markup/details/frontmatter/codeblock.json
+++ b/modules/platen/_docs/markup/details/frontmatter/codeblock.json
@@ -7,11 +7,12 @@
       "body": [
         "```details",
         "---",
-        "summary:  [[&summary]]",
-        "class:    [[class]]",
-        "id:       [[id]]",
-        "linkable: [[linkable]]",
-        "open:     [[open]]",
+        "summary:       [[&summary]]",
+        "class:         [[class]]",
+        "heading_level: [[level]]",
+        "id:            [[id]]",
+        "linkable:      [[linkable]]",
+        "open:          [[open]]",
         "---",
         "[[&selection]]",
         "```"
@@ -36,6 +37,12 @@
           "type": "string",
           "single": true,
           "default": ""
+        },
+        {
+          "name": "level",
+          "title": "The heading level to insert for the summary of the details element. This turns the details element into a collapsible section if the value is 1 through 6. The default (no heading) is 0.",
+          "type": "number",
+          "default": "0"
         },
         {
           "name": "id",

--- a/modules/platen/_docs/markup/details/index.md
+++ b/modules/platen/_docs/markup/details/index.md
@@ -21,6 +21,9 @@ Memo:
     summary:
       Type: String.Markdown.Inline
       Required: false
+    heading_level:
+      Type: Integer
+      Required: false
   Data:
     linkable:
       Type: Boolean
@@ -90,8 +93,9 @@ Another _Markdown_ example.
 
 `````````memo-example-renderer { title="YAML Options Parameter Example" }
 This example ensures the block is loaded in its collapsed state instead of open
-and sets the `linkable` option to `false`. That prevents Platen from adding an
-ID to the summary.
+and sets the `heading_level` option to `4`. That ensures Platen writes the
+summary inside an `<h4>` element, meaning the details block can show up in the
+table of contents.
 
 Note that this example also uses more backticks (`` ` ``) for the codeblock.
 That lets you include nested codeblocks inside the details. Here it's used to
@@ -101,7 +105,7 @@ add a [mermaid diagram](mermaid.md).
 ``````details
 ---
 summary: With Nested Codeblock
-linkable: false
+heading_level: 4
 open: false
 ---
 
@@ -125,6 +129,17 @@ Specify a string for the [sref:`class`][04] attribute of the details element. By
 class and the div element containing the content has the `markdown-inner` class.
 
 {{< memo/renderer/attribute "class" >}}
+
+### `heading_level` { #attribute-heading_level }
+
+Specify a number for the level of [sref:heading element (`<h1>-<h6>`)][05] that the summary text should be rendered
+inside. By default, the summary text isn't rendered inside a heading element.
+
+When this value is set to a positive number, the rendered text is wrapped in a heading element inside the
+[sref:`<summary>`][02] element. When this value is set to `0` or a negative number, the rendered text is not wrapped.
+When this value is greater than `6`, it's treated as `6`.
+
+{{< memo/renderer/attribute "heading_level" >}}
 
 ### `id` { #attribute-id }
 
@@ -150,6 +165,17 @@ Specify a string for the [sref:`class`][04] attribute of the details element. By
 class and the `div` element containing the content has the `markdown-inner` class.
 
 {{< memo/renderer/option "class" >}}
+
+### `heading_level` { #option-heading_level }
+
+Specify a number for the level of [sref:heading element (`<h1>-<h6>`)][05] that the summary text should be rendered
+inside. By default, the summary text isn't rendered inside a heading element.
+
+When this value is set to a positive number, the rendered text is wrapped in a heading element inside the
+[sref:`<summary>`][02] element. When this value is set to `0` or a negative number, the rendered text is not wrapped.
+When this value is greater than `6`, it's treated as `6`.
+
+{{< memo/renderer/option "heading_level" >}}
 
 ### `id` { #option-id }
 
@@ -192,3 +218,4 @@ Markdown, including other codeblocks. To use nested codeblocks, you must have mo
 [02]: mdn.html.element:summary
 [03]: mdn.html.element:div
 [04]: mdn.html.global_attribute:class
+[05]: mdn.html.element:Heading_Elements

--- a/modules/platen/assets/styles/markup/_details.scss
+++ b/modules/platen/assets/styles/markup/_details.scss
@@ -8,11 +8,25 @@
       line-height: 1;
       padding: $padding-large;
       margin: -$padding-large;
+      list-style: none;
+
       cursor: pointer;
+      > * {
+        display: inline-block;
+        margin: 0;
+      }
+
+      &::after {
+        float: right;
+        content: "+";
+      }
     }
 
     &[open] summary {
       margin-bottom: 0;
+      &::after {
+        content: "-";
+      }
     }
 
     @each $name, $color in $details-colors {
@@ -23,3 +37,8 @@
     }
   }
 }
+
+body[dir="rtl"] .markdown details summary::after {
+  float: left;
+}
+

--- a/modules/platen/layouts/partials/platen/markup/details/codeblock.html
+++ b/modules/platen/layouts/partials/platen/markup/details/codeblock.html
@@ -25,14 +25,37 @@
   {{- $info       := partial "platen/utils/getCodeblockInfo" $infoParams                       -}}
 
   {{/* Handle attributes and data */}}
-  {{- $class      := $info.Data.class    | default $Attributes.class                        -}}
-  {{- $summary    := $info.Data.summary  | default $Attributes.summary  | default "Details" -}}
-  {{- $linkable   := $info.Data.linkable | default $Attributes.linkable | default true      -}}
-  {{- $open       := $info.Data.open     | default $Attributes.open     | default true      -}}
-  {{- $id         := $info.Data.id
-                     | default $Attributes.id
-                     | default (lower $summary | urlize)
+  {{- $class        := $info.Data.class         | default $Attributes.class                             -}}
+  {{- $summary      := $info.Data.summary       | default $Attributes.summary       | default "Details" -}}
+  {{- $linkable     := $info.Data.linkable      | default $Attributes.linkable      | default true      -}}
+  {{- $open         := $info.Data.open          | default $Attributes.open          | default true      -}}
+  {{- $headingLevel := $info.Data.heading_level | default $Attributes.heading_level | default 0         -}}
+  {{- $id           := $info.Data.id
+                        | default $Attributes.id
+                        | default (lower $summary | urlize)
   -}}
+
+  {{/*  Munge heading levels - if string, make int. If invalid number, munge to closest.  */}}
+  {{- $headingLevel = int $headingLevel -}}
+  {{- if (lt $headingLevel 0) -}}
+    {{- $message := slice "Specified heading_level as %v for details markup at %s;"
+                          "valid values are 0-6, where zero isn't a heading."
+                          "Treating this value as 0."
+    -}}
+    {{- $message = delimit $message " " | print -}}
+    {{- warnf $message $headingLevel $Position  -}}
+    
+    {{- $headingLevel = 0 -}}
+  {{- else if (and (ne 0 $headingLevel) (gt $headingLevel 6)) -}}
+    {{- $message := slice "Specified heading_level as %v for details markup at %s;"
+                          "valid values are 0-6, where zero isn't a heading."
+                          "Treating this value as 6."
+    -}}
+    {{- $message = delimit $message " " | print -}}
+    {{- warnf $message $headingLevel $Position  -}}
+
+    {{- $headingLevel = 6 -}}
+  {{- end -}}
 
   {{/* Retrieve and trim the actual definition */}}
   {{- $trimParams   := dict "Text" $info.Markdown "TrimEOL" true                           -}}
@@ -46,9 +69,20 @@
   {{/* Build the list of attributes for the container element */}}
   {{- $detailsAttributes := slice -}}
   {{- $summaryAttributes := ""    -}}
-  {{- if $linkable -}}
+  {{/*  Headings always get IDs  */}}
+  {{- if or $linkable (ne 0 $headingLevel) -}}
     {{- $summaryAttributes = printf ` id="%s"` $id -}}
   {{- end -}}
+  
+  {{- $summaryHtml := printf "  <summary%s>\n    %s\n</summary>" $summaryAttributes $summary -}}
+  
+  {{/*  If the heading level is defined, place the summary text in the correct heading  */}}
+  {{- if ne 0 $headingLevel -}}
+    {{- $summaryHtml = printf `%s <a class="anchor" href="#%s">#</a>` $summary $id                          -}}
+    {{- $summaryHtml = printf "<h%v%s>%s</h%v>" $headingLevel $summaryAttributes $summaryHtml $headingLevel -}}
+    {{- $summaryHtml = printf "  <summary>\n    %s\n  </summary>" $summaryHtml                              -}}
+  {{- end -}}
+
   {{- $classes           := slice "platen-details" -}}
   {{- with $class -}}
     {{- $classes = $classes | append $class -}}
@@ -60,7 +94,7 @@
   {{- end -}}
   {{- $detailsAttributes = partial "platen/utils/getSafeAttributes" $detailsAttributes -}}
   {{- $lines := slice (printf "<details %s>" $detailsAttributes)
-                      (printf "  <summary%s>\n  %s\n</summary>" $summaryAttributes $summary)
+                      $summaryHtml
                       `  <div class="markdown-inner">`
                       (printf "    %s" $content)
                       "  </div>"


### PR DESCRIPTION
This change enables using the `details` markup to create collapsible sections by setting the `heading_level` for the markup to 1--6. By default, the summary text for `details` is added as rendered Markdown inside the summary tag. With this change, that rendered text is wrapped in a heading so it can show up in the table of contents.

This change also makes some minor improvements to the styling for the `details` elements:

- Replaces the default caret with a `+`/`-` toggle that floats to the end of the text, respecting language direction.
- Ensures all elements rendered inside the summary are rendered as inline blocks and without margins, ensuring nested heading elements do not break the flow.