### PR TITLE
(MAINT) Fix warnings for legacy templates

### DIFF
--- a/modules/platen/layouts/partials/platen/markup/buttons/_canonicalize.html
+++ b/modules/platen/layouts/partials/platen/markup/buttons/_canonicalize.html
@@ -189,7 +189,7 @@
 {{- if $options.legacy -}}
   {{- $template = "legacy" -}}
   {{- if $Config.warn_on_legacy -}}
-    {{- $message := slice "Used legacy template for buttons markup."
+    {{- $message := slice (printf "Used legacy template for buttons markup in '%s'." $Page.File.Path)
                           "This template is deprecated and will eventually be removed."
                           "For more information, see"
                           "https://platen.io/modules/platen/markup/buttons/#legacy-template"

--- a/modules/platen/layouts/partials/platen/markup/details/_canonicalize.html
+++ b/modules/platen/layouts/partials/platen/markup/details/_canonicalize.html
@@ -228,7 +228,7 @@ z{{- $Params     := .                  -}}
   {{- end -}}
 {{- else if $options.legacy -}}
   {{- if $Config.warn_on_legacy -}}
-    {{- $message := slice "Used legacy template for details markup."
+    {{- $message := slice (printf "Used legacy template for details markup at %s." $Position)
                           "This template is deprecated and will eventually be removed."
                           "For more information, see"
                           "https://platen.io/modules/platen/markup/details/#legacy-template"

--- a/modules/platen/layouts/partials/platen/markup/tabs/_canonicalize.html
+++ b/modules/platen/layouts/partials/platen/markup/tabs/_canonicalize.html
@@ -186,10 +186,10 @@
 {{- if $options.legacy -}}
   {{- $template = "legacy" -}}
   {{- if $Config.warn_on_legacy -}}
-    {{- $message := slice "Used legacy template for buttons markup."
+    {{- $message := slice (printf "Used legacy template for tabs markup at %s." $Position)
                           "This template is deprecated and will eventually be removed."
                           "For more information, see"
-                          "https://platen.io/modules/platen/markup/buttons/#legacy-template"
+                          "https://platen.io/modules/platen/markup/tabs/#legacy-template"
     -}}
     {{- warnf (delimit $message " " | print) -}}
   {{- end -}}


### PR DESCRIPTION
Prior to this change, the warnings for the legacy templates did not include any information about where the markup was used and the warning for the tabs markup incorrectly mentioned buttons.

This change:

1. Adds position information for the details and tabs legacy markup, as those use a codeblock renderer that includes the position.
1. Adds file information for the buttons legacy markup.
1. Corrects the warning for the tabs markup to point to the correct docs page and warn about tabs instead of buttons.