### PR TITLE
(MAINT) Fix schematize ref resolution

### DIFF
--- a/modules/schematize/layouts/partials/schematize/utils/references/resolve/data.html
+++ b/modules/schematize/layouts/partials/schematize/utils/references/resolve/data.html
@@ -2,18 +2,23 @@
   Resolve the reference to a references schema data. This is only supported for locally defined
   schemas and may behave strangely if accidentally called for external schemas.
 */}}
-{{- $params   := .                                                  -}}
-{{- $property := $params.property                                   -}}
-{{- $refPath  := replaceRE "\\.yaml" "" (index $property "$ref")    -}}
-{{- $pointer  := ""                                                 -}}
+{{- $params     := .                                               -}}
+{{- $property   := $params.property                                -}}
+{{- $refPath    := replaceRE "\\.yaml" "" (index $property "$ref") -}}
+{{- $HomeRelRef := relref $params.page (dict "path" "/_index.md")  -}}
+{{- $pointer    := ""                                              -}}
+
+{{- $PagePath := $params.page.File.Path -}}
 
 {{- if in $refPath "#/" -}}
-  {{- $Parts := split $refPath "#/"                    -}}
-  {{- $refPath = index $Parts 0                        -}}
-  {{- $pointer = printf "#/%s" (index $Parts 1)          -}}
+  {{- $Parts  := split $refPath "#/"            -}}
+  {{- $refPath = index $Parts 0                 -}}
+  {{- $pointer = printf "#/%s" (index $Parts 1) -}}
 {{- end -}}
 
-{{- $refPath   = relref $params.page (dict "path" $refPath) | print -}}
+{{- $refPath = relref $params.page (dict "path" $refPath) | print -}}
+{{/*  Support sites with base URLs that have a suffix, like https://foo.com/bar - replaces '/bar/' with '/'  */}}
+{{- $refPath = replace $refPath $HomeRelRef "/" -}}
 
 {{- if hasPrefix $refPath "/schemas" -}}
   {{/* This is how everything was originally implemented. Keep this as a fallback. */}}
@@ -31,9 +36,9 @@
     {{- $suffix = "/schema.json" -}}
   {{- end -}}
   {{- $refPagePath := strings.TrimSuffix $suffix $refPath -}}
-  {{- $refPagePath  = printf "%s.md" $refPagePath     -}}
-  {{- $refPage     := site.GetPage $refPagePath       -}}
-  {{- $refPath      = $refPage.Params.schematize      -}}
+  {{- $refPagePath  = printf "%s.md" $refPagePath         -}}
+  {{- $refPage     := site.GetPage $refPagePath           -}}
+  {{- $refPath      = $refPage.Params.schematize          -}}
 {{- end -}}
 {{- $refLevel := default 0 $property._level -}}
 {{/* Still hard coded to schemas folder */}}


### PR DESCRIPTION
Prior to this change, the logic for the schematize resolver for data only worked when the base URL pointed to the base of a website, like `https://foo.com`, not `https://foo.com/bar`.

When the base URL had a suffix after the domain name, the partial resolved the relative path to the file as `/suffix/...` instead of `/...`, which the `site.GetPage` function could not resolve, since the content does not live in a `suffix` folder in the content.

This change munges the prefix for site-relative paths in the resolution to use `/` as the prefix, even when the site is hosted in a folder on the domain.