### PR TITLE
(MAINT) Improve integration with Shoelace

### DIFF
--- a/content/using/legacy.md
+++ b/content/using/legacy.md
@@ -1,0 +1,189 @@
+---
+title: Migrating from Legacy Settings
+linkTitle: Legacy Settings
+summary: Help for updating your Platen site to use newer features.
+weight: 99
+---
+
+In a recent release, Platen added much stronger integration with [sref:Shoelace][s01]. This brings a host of benefits,
+especially around composing configurable theme components and icons.
+
+With this release, Platen raises a warning when you use legacy components and markup, but still defaults to those
+legacy implementations. In the future, the new components and markup will become the default. Later, opting to use the
+legacy options will raise an error instead of a warning. Finally, the legacy implementations will be removed.
+
+We **strongly** recommend you migrate your site and any theme customizations to use the new components and markup.
+
+## Display Updates
+
+The `display` section of the configuration has expanded to cover several new features, replacing old non-configurable
+components of the theme with much more configurable and functional components.
+
+### Table of Contents
+
+The table of contents (TOC) implementation has been reworked from a minimalist set of nested list items that linked to
+the headings on the current page to a collapsible list of links using Shoelace's [sref:Tree][s02] and
+[sref:Tree Item][s03] components.
+
+If you enable the updated TOC, you can customize the indentation for the TOC as well as the collapse and expand icons.
+Further, the implementation supports adding icons before and after the link text in the TOC by specifying attributes on
+headings in your Markdown.
+
+### Multilingual Languages Icon
+
+For multilingual sites, the languages icon in the site menu that displays for the translated pages dropdown is now
+implemented as a Shoelace [sref:Icon][s04] and is configurable. You can use the `platen.display.menu.languages_icon`
+settings to configure it.
+
+### Mobile Controls Buttons
+
+The controls at the top of content pages for showing the site menu and the table of contents have been updated to use
+Shoelace's [sref:Icon Buttons][s05]. They use Shoelace's [sref:Tooltip][s06] to display extra information when you
+hover on them. You can configure both buttons with the `menu_control` and `toc_control` settings in
+`platen.display.mobile`. You can override the icons, the tooltips, and the accessibility labels.
+
+### Footer Link Buttons
+
+The links at the bottom of the page for seeing the last edit to a page and editing it online have been reworked.
+Instead of links, they're now Shoelace [sref:Buttons][s07].
+
+The new button for the last edited on link now displays how long its been since the page was last updated. If you
+hover on the button, it displays the localized time and date for that last update. Clicking the link takes you to the
+commit that last updated the file.
+
+The new button for the edit this page link is simpler and doesn't have a tooltip.
+
+You can configure both buttons, including replacing their icons, updating their text, or removing them entirely, with
+the `last_edited_on` and `edit_this_page` settings in `platen.display.footer`.
+
+### Updating Your Configuration
+
+To update your configuration to use the new display settings, you can either update the `_params/platen/display.yaml`
+file in your site's [`data` folder][h01] or your `hugo.yaml` site configuration file.
+
+For your convenience, Platen supports configuring your site with data files in the `_params` folder. If you followed
+the [Happy Path][01] when setting up your site, or if you used the [Platen Template][02], you already have the data
+files and folders created for configuring Platen from your site data.
+
+The tabs below explain how you can use either option to update your configuration and take advantage of the new
+functionality.
+
+`````````tabs
+``````tab
+---
+name: Updating in `data/_params`
+---
+Update the `_params/platen/display.yaml` file in your site's `data` folder.
+
+Make sure the settings below are defined correctly in the file.
+
+```yaml
+table_of_contents:
+  languages_icon:
+    use_legacy: false
+mobile:
+  menu_control:
+    use_legacy: false
+  toc_control:
+    use_legacy: false
+footer:
+  last_edited_on:
+    use_legacy: false
+  edit_this_page:
+    use_legacy: false
+```
+``````
+
+``````tab
+---
+name: Updating in `hugo.yaml`
+---
+
+If you'd rather manage your configuration options in a single configuration 
+file, you can edit your `hugo.yaml` file.
+
+Ensure the following key-value pairs are set in your `hugo.yaml` configuration
+file.
+
+```yaml
+platen:
+  display:
+    table_of_contents:
+      languages_icon:
+        use_legacy: false
+    mobile:
+      menu_control:
+        use_legacy: false
+      toc_control:
+        use_legacy: false
+    footer:
+      last_edited_on:
+        use_legacy: false
+      edit_this_page:
+        use_legacy: false
+```
+
+```alert
+We strongly recommend using the data files to manage your configuration if
+you're setting more than one or two options. It's much more maintainable in
+the long run. Each configuration section is easier to read.
+```
+``````
+`````````
+
+## Markup
+
+Alongside general components, Platen has updated older markup to use Shoelace components, making them more customizable.
+
+### Buttons
+
+The [buttons][03] markup used to display a normal link that Platen styled to look like a button. Now the markup renders
+[sref:Shoelace Buttons][s07], which are much more configurable. To see the full list of new options, see the markup's
+[documentation][03].
+
+A few highlights include being able to add icons to your buttons, change their shape and color, and indicate that the
+button downloads a file.
+
+To enable the new buttons markup, set `platen.markup.buttons.use_legacy` to `false` in your site configuration or in
+the `_params/platen/markup.yaml` file in your site's data folder.
+
+### Details
+
+The [details][04] markup used to display an HTML [sref:`<details>`][m01] element that required classes to customize.
+Now this markup renders [sref:Shoelace Details][s08], which are more configurable.
+
+With the new markup, you can configure the icons displayed on the details block to indicate that a reader can collapse
+or expand the block.
+
+To enable the new details markup, set `platen.markup.details.use_legacy` to `false` in your site configuration or in
+the `_params/platen/markup.yaml` file in your site's data folder.
+
+### Tabs
+
+The [tabs][05] markup used to display tabbed content in [sref:`<div>`][m02] elements controlled by custom inputs and
+required classes to customize. Now, this markup renders a [sref:Shoelace Tab Group][s09] instead. To see the full list
+of new options, see the markup's [documentation][03].
+
+A few highlights include customizing where tabs are placed relative to their content, defining closable tabs, and
+making tabs scrollable when they don't fit on the page.
+
+To enable the new tabs markup, set `platen.markup.tabs.use_legacy` to `false` in your site configuration or in the
+`_params/platen/markup.yaml` file in your site's data folder.
+
+[s01]: sl.component:
+[s02]: sl.component:tree
+[s03]: sl.component:tree-item
+[s04]: sl.component:icon
+[s05]: sl.component:icon-button
+[s06]: sl.component:tooltip
+[s07]: sl.component:button
+[s08]: sl.component:details
+[s09]: sl.component:tab-group
+[h01]: https://gohugo.io/getting-started/directory-structure/#directory-structure-explained
+[m01]: mdn.html.element:details
+[m02]: mdn.html.element:div
+[01]: /getting-started/happy-path-setup/
+[02]: https://github.com/platenio/platen-template
+[03]: /modules/platen/markup/buttons/
+[04]: /modules/platen/markup/details/
+[05]: /modules/platen/markup/tabs/

--- a/data/_params/platen/display.yaml
+++ b/data/_params/platen/display.yaml
@@ -2,15 +2,28 @@
 table_of_contents:
   minimum_level: 1
   maximum_level: 6
+  use_legacy: false
 date_format: "January 2, 2006"
 menu:
   root_section: /
+  languages_icon:
+    use_legacy: false
   before_injection:
     entries:
       - feature: toroidal
         weight: 1
         page_path: sites/platen
         display_name: Platen Sites
+mobile:
+  menu_control:
+    use_legacy: false
+  toc_control:
+    use_legacy: false
+footer:
+  last_edited_on:
+    use_legacy: false
+  edit_this_page:
+    use_legacy: false
 logo:
   url: /images/logo.svg
 header:

--- a/data/platen/buttons/label_icon/object.yaml
+++ b/data/platen/buttons/label_icon/object.yaml
@@ -1,3 +1,7 @@
-prefix_icon:
-  name: gear
-  style: "color: #417505;"
+label_icon:
+  library: boxicons
+  name:    cog
+  variant: solid
+  style: >-
+    color: #417505;
+    opacity: 50%;

--- a/data/platen/buttons/label_icon/string.yaml
+++ b/data/platen/buttons/label_icon/string.yaml
@@ -1,1 +1,1 @@
-prefix_icon: gear
+label_icon: cog&solid@boxicons

--- a/data/platen/buttons/prefix/object.yaml
+++ b/data/platen/buttons/prefix/object.yaml
@@ -1,3 +1,7 @@
 prefix_icon:
-  name: gear
-  style: "color: #417505;"
+  library: boxicons
+  name:    cog
+  variant: solid
+  style: >-
+    color: #417505;
+    opacity: 50%;

--- a/data/platen/buttons/prefix/string.yaml
+++ b/data/platen/buttons/prefix/string.yaml
@@ -1,1 +1,1 @@
-prefix_icon: gear
+prefix_icon: cog&solid@boxicons

--- a/data/platen/buttons/suffix/object.yaml
+++ b/data/platen/buttons/suffix/object.yaml
@@ -1,3 +1,7 @@
-prefix_icon:
-  name: gear
-  style: "color: #417505;"
+suffix_icon:
+  library: boxicons
+  name:    cog
+  variant: solid
+  style: >-
+    color: #417505;
+    opacity: 50%;

--- a/data/platen/buttons/suffix/string.yaml
+++ b/data/platen/buttons/suffix/string.yaml
@@ -1,1 +1,1 @@
-prefix_icon: gear
+suffix_icon: cog&solid@boxicons

--- a/modules/platen/_docs/config/site/display/footer.md
+++ b/modules/platen/_docs/config/site/display/footer.md
@@ -1,0 +1,16 @@
+---
+name: Footer
+title: Footer
+summary: |
+  Optional settings controlling the footer for pages in Platen
+weight: 2
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.display.footer
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/display/menu/_index.md
+++ b/modules/platen/_docs/config/site/display/menu/_index.md
@@ -2,7 +2,7 @@
 name: Menu
 title: Menu
 summary: Schemas for Platen's Menu Configuration
-weight: 2
+weight: 3
 platen:
   menu:
     collapse_section: true

--- a/modules/platen/_docs/config/site/display/mobile.md
+++ b/modules/platen/_docs/config/site/display/mobile.md
@@ -1,0 +1,16 @@
+---
+name: Mobile
+title: Mobile
+summary: |
+  Optional settings controlling how a Platen site looks on smaller screens.
+weight: 4
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.display.mobile
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/_index.md
+++ b/modules/platen/_docs/config/site/features/shoelace/_index.md
@@ -1,0 +1,7 @@
+---
+name: Shoelace
+title: Shoelace
+weight: 5
+platen:
+  collapse_section: true
+---

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/_index.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/_index.md
@@ -1,0 +1,7 @@
+---
+name: Icon Libraries
+title: Icon Libraries
+weight: 3
+platen:
+  collapse_section: true
+---

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/boxicons.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/boxicons.md
@@ -1,0 +1,16 @@
+---
+name: Boxicons
+title: Boxicons
+summary: |
+  Options for the Boxicons icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.boxicons
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/default.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/default.md
@@ -1,0 +1,16 @@
+---
+name: Builtin Bootstrap
+title: Builtin Bootstrap
+summary: |
+  Options for the builtin bootstrap icon library available by default.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.default
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/font_awesome.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/font_awesome.md
@@ -1,0 +1,16 @@
+---
+name: Font Awesome
+title: Font Awesome
+summary: |
+  Options for the Font Awesome icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.font_awesome
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/heroicons.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/heroicons.md
@@ -1,0 +1,16 @@
+---
+name: Heroicons
+title: Heroicons
+summary: |
+  Options for the Heroicons icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.heroicons
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/iconoir.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/iconoir.md
@@ -1,0 +1,16 @@
+---
+name: Iconoir
+title: Iconoir
+summary: |
+  Options for the Iconoir icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.iconoir
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/ionicons.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/ionicons.md
@@ -1,0 +1,16 @@
+---
+name: Ionicons
+title: Ionicons
+summary: |
+  Options for the Ionicons icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.ionicons
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/jam_icons.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/jam_icons.md
@@ -1,0 +1,16 @@
+---
+name: Jam Icons
+title: Jam Icons
+summary: |
+  Options for the Jam Icons icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.jam_icons
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/lucide.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/lucide.md
@@ -1,0 +1,16 @@
+---
+name: Lucide
+title: Lucide
+summary: |
+  Options for the Lucide icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.lucide
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/material_icons.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/material_icons.md
@@ -1,0 +1,16 @@
+---
+name: Material Icons
+title: Material Icons
+summary: |
+  Options for the Material Icons icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.material_icons
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/remix_icon.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/remix_icon.md
@@ -1,0 +1,16 @@
+---
+name: Remix Icon
+title: Remix Icon
+summary: |
+  Options for the Remix Icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.remix_icon
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/tabler_icons.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/tabler_icons.md
@@ -1,0 +1,16 @@
+---
+name: Tabler Icons
+title: Tabler Icons
+summary: |
+  Options for the Tabler Icons library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.tabler_icons
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/icon_libraries/unicons.md
+++ b/modules/platen/_docs/config/site/features/shoelace/icon_libraries/unicons.md
@@ -1,0 +1,16 @@
+---
+name: Unicons
+title: Unicons
+summary: |
+  Options for the Unicons icon library.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.icon_libraries.unicons
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/config/site/features/shoelace/options.md
+++ b/modules/platen/_docs/config/site/features/shoelace/options.md
@@ -1,0 +1,16 @@
+---
+name: Options
+title: Shoelace Options
+summary: |
+  Optional settings controlling how a Platen site looks on smaller screens.
+weight: 1
+type: schematize
+platen:
+  title_as_heading: false
+schematize: platen.site.features.shoelace.options
+outputs:
+  - HTML
+  - Schematize
+---
+
+{{% schematize %}}

--- a/modules/platen/_docs/markup/alerts/index.md
+++ b/modules/platen/_docs/markup/alerts/index.md
@@ -979,7 +979,7 @@ the name for the style module `assets/styles/markup/_foo.scss` is `foo`.
 [sref:`<span>`]:              mdn.html.element:span
 [sref:`<sl-alert>`]:          sl.component:tab-panel
 [sref:`<sl-icon>`]:           sl.component:icon
-[sref:any valid icon]:        sl.compponent:icon?default-icons
+[sref:any valid icon]:        sl.component:icon?default-icons
 [sref:Shoelace]:              sl:
 [c01]: platen.site.markup.alerts.custom
 [c02]: platen.site.markup.alerts.preset

--- a/modules/platen/_docs/markup/alerts/index.md
+++ b/modules/platen/_docs/markup/alerts/index.md
@@ -201,14 +201,43 @@ This example shows an alert with a custom icon defined by the
 [`icon` option](#options-icon). It also includes a header before the body of
 the alert, defined with the [`header` option](#options-header).
 
+The first example uses the shorthand syntax with the default icon library and
+only specifies the icons name. The second example uses the full shorthand
+syntax to specify the icon's name, variant, and library. The last example uses
+the option syntax, explicitly setting the name, variant, and library as
+key-value pairs. For more information, see the `icon` option's documentation.
+
 <!--- Example Start -->
 
 ```alert
 ---
-icon: hammer
+icon: cone-striped
 header: "**Under Construction!**"
 ---
 This section isn't fully finished. If you find any issues, let us know!
+```
+
+```alert
+---
+icon: traffic-cone&solid@boxicons
+header: "**Under Construction!**"
+---
+This section isn't fully finished. If you find any issues, let us know!
+
+This alert uses the full shorthand syntax for the icon.
+```
+
+```alert
+---
+icon:
+  name:    traffic-cone
+  library: boxicons
+  variant: solid
+header: "**Under Construction!**"
+---
+This section isn't fully finished. If you find any issues, let us know!
+
+This alert uses the options syntax for the icon.
 ```
 ``````
 
@@ -328,7 +357,7 @@ the alert. Platen renders the header's inline Markdown and inserts it into an [s
 ### `icon` { #options-icon }
 
 Specify an icon to add to the start of the rendered [sref:`<sl-alert>`] in an [sref:`<sl-icon>`] element. You can
-specify the name of [sref:any valid icon].
+specify the icon either as a string using the shorthand syntax or as a map of options for the icon.
 
 If your markup doesn't specify a value for `icon` with this data option or the
 [preset property](#preset-properties-icon), it uses the icon defined for the alert's variant in the
@@ -336,6 +365,33 @@ If your markup doesn't specify a value for `icon` with this data option or the
 information, see the [`use_default_icons`](#options-use_default_icons) option and [Configuration](#configuration).
 
 {{< memo/renderer/option "icon" >}}
+
+#### Shorthand Syntax { #options-icon-shorthand-syntax }
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support variants. When
+  you specify a variant in this syntax, you must specify it after the icon's name. You must separate the variant from
+  the icon name with an ampersand (`&`). When you don't specify a variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When you specify a library in this syntax,
+  you must specify it after the icon's name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the configured default library.
+
+You can always use [sref:any valid icon] in Shoelace's default icon library.
+
+#### Options Syntax { #options-icon-options-syntax }
+
+The options syntax for icons is:
+
+```yaml
+name:    icon_name    # Mandatory
+library: icon_library # Optional
+variant: icon_variant # Optional
+```
+
+You can also pass any valid [sref:global HTML attribute] in the options map for the icon, like `class` or `style`.
+Those attributes are passed through to the icon element.
 
 ### `id` { #options-id }
 
@@ -575,12 +631,39 @@ the alert. Platen renders the header's inline Markdown and inserts it into an [s
 ### `icon` { #preset-properties-icon }
 
 Specify an icon to add to the start of the rendered [sref:`<sl-alert>`] in an [sref:`<sl-icon>`] element. You can
-specify the name of [sref:any valid icon].
+specify the icon either as a string using the shorthand syntax or as a map of options for the icon.
 
-If your markup doesn't specify a value for `icon` with this preset property or the [data option](#options-icon), it
-uses the icon defined for the alert's variant in the `platen.markup.alerts.icons` setting in your site configuration if
-the value of `use_default_icons` is `true`. For more information, see the
-[`use_default_icons`](#preset-properties-use_default_icons) preset property and [Configuration](#configuration).
+If your markup doesn't specify a value for `icon` with this preset property or the
+[data option](#options-icon), it uses the icon defined for the alert's variant in the
+`platen.markup.alerts.icons` setting in your site configuration if the value of `use_default_icons` is `true`. For more
+information, see the [`use_default_icons`](#options-use_default_icons) option and [Configuration](#configuration).
+
+#### Shorthand Syntax { #preset-properties-icon-shorthand-syntax }
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support variants. When
+  you specify a variant in this syntax, you must specify it after the icon's name. You must separate the variant from
+  the icon name with an ampersand (`&`). When you don't specify a variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When you specify a library in this syntax,
+  you must specify it after the icon's name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the configured default library.
+
+You can always use [sref:any valid icon] in Shoelace's default icon library.
+
+#### Options Syntax { #preset-properties-icon-options-syntax }
+
+The options syntax for icons is:
+
+```yaml
+name:    icon_name    # Mandatory
+library: icon_library # Optional
+variant: icon_variant # Optional
+```
+
+You can also pass any valid [sref:global HTML attribute] in the options map for the icon, like `class` or `style`.
+Those attributes are passed through to the icon element.
 
 ### `id` { #preset-properties-id }
 
@@ -814,7 +897,7 @@ defaults to `assets` in your project root.
 
 ``````details
 ---
-summary: Tabs SCSS
+summary: Alerts SCSS
 heading_level: 3
 ---
 
@@ -890,13 +973,14 @@ the name for the style module `assets/styles/markup/_foo.scss` is `foo`.
 <!-- Reference Link Definitions -->
 [01]: /using
 [02]: /using
-[sref:`id`]:           mdn.html.global_attribute:id
-[sref:`class`]:        mdn.html.global_attribute:class
-[sref:`<span>`]:       mdn.html.element:span
-[sref:`<sl-alert>`]:   sl.component:tab-panel
-[sref:`<sl-icon>`]:    sl.component:icon
-[sref:any valid icon]: sl.compponent:icon?default-icons
-[sref:Shoelace]:       sl:
+[sref:global HTML attribute]: mdn.html.global_attribute:
+[sref:`id`]:                  mdn.html.global_attribute:id
+[sref:`class`]:               mdn.html.global_attribute:class
+[sref:`<span>`]:              mdn.html.element:span
+[sref:`<sl-alert>`]:          sl.component:tab-panel
+[sref:`<sl-icon>`]:           sl.component:icon
+[sref:any valid icon]:        sl.compponent:icon?default-icons
+[sref:Shoelace]:              sl:
 [c01]: platen.site.markup.alerts.custom
 [c02]: platen.site.markup.alerts.preset
 [c03]: platen.site.markup.alerts.classes

--- a/modules/platen/_docs/markup/buttons/index.md
+++ b/modules/platen/_docs/markup/buttons/index.md
@@ -242,9 +242,9 @@ attribute to render the button as a circle around the icon.
 
 <br />
 
-![button:](https://flagrant.garden "gear")
+![button:](https://flagrant.garden "cog@boxicons")
 
-![button:](https://flagrant.garden "gear")
+![button:](https://flagrant.garden "cog&solid@boxicons")
 { circle=true }
 ```
 
@@ -411,11 +411,26 @@ This option isn't valid with the [legacy button](#legacy-template).
 
 ### `prefix_icon`
 
-Use this attribute to insert an icon before your label text. You can use any [sref:valid icon][sl01] from Shoelace.
+Use this attribute to insert an icon before your label text. You can specify the icon as a string using the shorthand
+syntax for icons.
 
 This option isn't valid with the [legacy button](#legacy-template).
 
 {{< memo/renderer/attribute "prefix_icon" >}}
+
+#### Shorthand Syntax { #prefix_icon-shorthand-syntax }
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support variants. When
+  you specify a variant in this syntax, you must specify it after the icon's name. You must separate the variant from
+  the icon name with an ampersand (`&`). When you don't specify a variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When you specify a library in this syntax,
+  you must specify it after the icon's name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the configured default library.
+
+You can find the [sref:list of available icons in the default library in Shoelace's documentation][sl01].
 
 ### `preset` { #attributes-preset }
 
@@ -466,11 +481,24 @@ This option isn't valid with the [legacy button](#legacy-template).
 
 ### `suffix_icon`
 
-Use this attribute to insert an icon after your label text. You can use any [sref:valid icon][sl01] from Shoelace.
+Use this attribute to insert an icon after your label text. You can specify the icon as a string using the shorthand
+syntax for icons.
 
 This option isn't valid with the [legacy button](#legacy-template).
 
 {{< memo/renderer/attribute "suffix_icon" >}}
+
+#### Shorthand Syntax { #prefix_icon-shorthand-syntax }
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support variants. When
+  you specify a variant in this syntax, you must specify it after the icon's name. You must separate the variant from
+  the icon name with an ampersand (`&`). When you don't specify a variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When you specify a library in this syntax,
+  you must specify it after the icon's name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the configured default library.
 
 ### `target`
 
@@ -663,16 +691,32 @@ This option isn't valid with the [legacy button](#legacy-template).
 Use this property to insert an icon instead of label text. When you specify this property, Platen ignores the value for
 `label_text`.
 
-If this property's value is a string, it must be the name of the icon. You can use any [sref:valid icon][sl01] from
-Shoelace. With this property, you can also define attributes to pass to the label icon.
+If this property's value is a string, it must be the shorthand syntax for an icon. With this property, you can also
+define attributes to pass to the label icon.
 
 `````````tabs { #preset-property-label_icon-values }
-``````tab { name="As String" }
-In this case, the value of `label_icon` is the name of the icon to insert.
+``````tab { name="As String (Shorthand Syntax)" }
+In this case, the value of `label_icon` must use the shorthand syntax for icons
+in Platen.
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`,
+where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all
+  icons and libraries support variants. When you specify a variant in this
+  syntax, you must specify it after the icon's name. You must separate the
+  variant from the icon name with an ampersand (`&`). When you don't specify a
+  variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When
+  you specify a library in this syntax, you must specify it after the icon's
+  name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the
+  configured default library.
 
 ```yaml
 # data/platen/buttons/label_icon/string.yaml
-label_icon: gear
+label_icon: cog&solid@boxicons
 ```
 
 ![button:String Configuration](https://platen.io)
@@ -681,12 +725,32 @@ label_icon: gear
 
 ``````tab { name="As Object with Properties" }
 In this case, the value of `label_icon` is an object with defined properties.
+You must specify the `name` property for the icon. You can specify the
+`library` and `variant` properties as needed.
+
+You can also pass any valid [sref:global HTML attribute][01] in the options map
+for the icon, like `class` or `style`. Those attributes are passed through to
+the icon element.
+
+[01]: mdn.html.global_attribute:
+
+```alert
+Note that the `style` property in this example uses the `>-` syntax after the
+key name. The content is then indented and it defines one CSS style setting on
+each line. We strongly recommend you use this syntax---it's more readable and
+easier to maintain. Remember that inline styles must have a semi-colon (`;`)
+after each style entry.
+```
 
 ```yaml
 # data/platen/buttons/label_icon/object.yaml
 label_icon:
-  name: gear
-  style: "color: #417505;"
+  library: boxicons
+  name:    cog
+  variant: solid
+  style: >-
+    color: #417505;
+    opacity: 50%;
 ```
 
 ![button:Object Configuration](https://platen.io)
@@ -699,17 +763,29 @@ This option isn't valid with the [legacy button](#legacy-template).
 #### `name` { #preset-property-label_icon-name }
 
 If you're specifying the `label_icon` as an object, this property is required. The value must be the name of the icon.
-You can use any [sref:valid icon][sl01] from Shoelace.
+You can use any [sref:valid icon][sl01] from Shoelace's default library or the name of an icon from any other
+configured icon library.
 
 #### `label` { #preset-property-label_icon-label }
 
 Specify an alternate description to use for assistive devices. If omitted, the icon will be considered presentational
 and ignored by assistive devices.
 
+#### `library` { #preset-property-label_icon-library }
+
+Specify the library the icon belongs to. If you omit this property, Platen uses the configured default icon library.
+
 #### `src` { #preset-property-label_icon-src }
 
 Specify the URL of an SVG file to use as the icon. Be sure you trust the content you are including, as it will be
 executed as code and can result in XSS attacks.
+
+If you specify this option, Platen ignores the values for `name`, `variant`, and `library` for the icon.
+
+#### `variant` { #preset-property-label_icon-variant }
+
+Specify the variant of the icon to use. Not all icons and libraries support variants. When you don't specify a variant,
+Platen uses the library's default variant.
 
 #### Other Attributes
 
@@ -839,16 +915,32 @@ This option isn't valid with the [legacy button](#legacy-template).
 
 Use this property to insert an icon before your label text.
 
-If this property's value is a string, it must be the name of the icon. You can use any [sref:valid icon][sl01] from Shoelace.
-With this property, you can also define attributes to pass to the prefix icon.
+If this property's value is a string, it must be the shorthand syntax for an icon. With this property, you can also
+define attributes to pass to the prefix icon.
 
 `````````tabs { #preset-property-prefix_icon-values }
-``````tab { name="As String" }
-In this case, the value of `prefix_icon` is the name of the icon to insert.
+``````tab { name="As String (Shorthand Syntax)" }
+In this case, the value of `prefix_icon` must use the shorthand syntax for
+icons in Platen.
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`,
+where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all
+  icons and libraries support variants. When you specify a variant in this
+  syntax, you must specify it after the icon's name. You must separate the
+  variant from the icon name with an ampersand (`&`). When you don't specify a
+  variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When
+  you specify a library in this syntax, you must specify it after the icon's
+  name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the
+  configured default library.
 
 ```yaml
 # data/platen/buttons/prefix/string.yaml
-prefix_icon: gear
+prefix_icon: cog&solid@boxicons
 ```
 
 ![button:String Configuration](https://platen.io)
@@ -857,12 +949,32 @@ prefix_icon: gear
 
 ``````tab { name="As Object with Properties" }
 In this case, the value of `prefix_icon` is an object with defined properties.
+You must specify the `name` property for the icon. You can specify the
+`library` and `variant` properties as needed.
+
+You can also pass any valid [sref:global HTML attribute][01] in the options map
+for the icon, like `class` or `style`. Those attributes are passed through to
+the icon element.
+
+[01]: mdn.html.global_attribute:
+
+```alert
+Note that the `style` property in this example uses the `>-` syntax after the
+key name. The content is then indented and it defines one CSS style setting on
+each line. We strongly recommend you use this syntax---it's more readable and
+easier to maintain. Remember that inline styles must have a semi-colon (`;`)
+after each style entry.
+```
 
 ```yaml
 # data/platen/buttons/prefix/object.yaml
 prefix_icon:
-  name: gear
-  style: "color: #417505;"
+  library: boxicons
+  name:    cog
+  variant: solid
+  style: >-
+    color: #417505;
+    opacity: 50%;
 ```
 
 ![button:Object Configuration](https://platen.io)
@@ -875,17 +987,29 @@ This option isn't valid with the [legacy button](#legacy-template).
 #### `name` { #preset-property-prefix_icon-name }
 
 If you're specifying the `prefix_icon` as an object, this property is required. The value must be the name of the icon.
-You can use any [sref:valid icon][sl01] from Shoelace.
+You can use any [sref:valid icon][sl01] from Shoelace's default library or the name of an icon from any other
+configured icon library.
 
 #### `label` { #preset-property-prefix_icon-label }
 
 Specify an alternate description to use for assistive devices. If omitted, the icon will be considered presentational
 and ignored by assistive devices.
 
+#### `library` { #preset-property-prefix_icon-library }
+
+Specify the library the icon belongs to. If you omit this property, Platen uses the configured default icon library.
+
 #### `src` { #preset-property-prefix_icon-src }
 
 Specify the URL of an SVG file to use as the icon. Be sure you trust the content you are including, as it will be
 executed as code and can result in XSS attacks.
+
+If you specify this option, Platen ignores the values for `name`, `variant`, and `library` for the icon.
+
+#### `variant` { #preset-property-prefix_icon-variant }
+
+Specify the variant of the icon to use. Not all icons and libraries support variants. When you don't specify a variant,
+Platen uses the library's default variant.
 
 #### Other Attributes
 
@@ -932,16 +1056,32 @@ This option isn't valid with the [legacy button](#legacy-template).
 
 Use this property to insert an icon after your label text.
 
-If this property's value is a string, it must be the name of the icon. You can use any [sref:valid icon][sl01] from
-Shoelace. With this property, you can also define attributes to pass to the suffix icon.
+If this property's value is a string, it must be the shorthand syntax for an icon. With this property, you can also
+define attributes to pass to the label icon.
 
 `````````tabs { #preset-property-suffix_icon-values }
-``````tab { name="As String" }
-In this case, the value of `suffix_icon` is the name of the icon to insert.
+``````tab { name="As String (Shorthand Syntax)" }
+In this case, the value of `suffix_icon` must use the shorthand syntax for
+icons in Platen.
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`,
+where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all
+  icons and libraries support variants. When you specify a variant in this
+  syntax, you must specify it after the icon's name. You must separate the
+  variant from the icon name with an ampersand (`&`). When you don't specify a
+  variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When
+  you specify a library in this syntax, you must specify it after the icon's
+  name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the
+  configured default library.
 
 ```yaml
 # data/platen/buttons/suffix/string.yaml
-suffix_icon: gear
+suffix_icon: cog&solid@boxicons
 ```
 
 ![button:String Configuration](https://platen.io)
@@ -950,12 +1090,32 @@ suffix_icon: gear
 
 ``````tab { name="As Object with Properties" }
 In this case, the value of `suffix_icon` is an object with defined properties.
+You must specify the `name` property for the icon. You can specify the
+`library` and `variant` properties as needed.
+
+You can also pass any valid [sref:global HTML attribute][01] in the options map
+for the icon, like `class` or `style`. Those attributes are passed through to
+the icon element.
+
+[01]: mdn.html.global_attribute:
+
+```alert
+Note that the `style` property in this example uses the `>-` syntax after the
+key name. The content is then indented and it defines one CSS style setting on
+each line. We strongly recommend you use this syntax---it's more readable and
+easier to maintain. Remember that inline styles must have a semi-colon (`;`)
+after each style entry.
+```
 
 ```yaml
 # data/platen/buttons/suffix/object.yaml
 suffix_icon:
-  name: gear
-  style: "color: #417505;"
+  library: boxicons
+  name:    cog
+  variant: solid
+  style: >-
+    color: #417505;
+    opacity: 50%;
 ```
 
 ![button:Object Configuration](https://platen.io)
@@ -968,17 +1128,29 @@ This option isn't valid with the [legacy button](#legacy-template).
 #### `name` { #preset-property-suffix_icon-name }
 
 If you're specifying the `suffix_icon` as an object, this property is required. The value must be the name of the icon.
-You can use any [sref:valid icon][sl01] from Shoelace.
+You can use any [sref:valid icon][sl01] from Shoelace's default library or the name of an icon from any other
+configured icon library.
 
 #### `label` { #preset-property-suffix_icon-label }
 
 Specify an alternate description to use for assistive devices. If omitted, the icon will be considered presentational
 and ignored by assistive devices.
 
+#### `library` { #preset-property-suffix_icon-library }
+
+Specify the library the icon belongs to. If you omit this property, Platen uses the configured default icon library.
+
 #### `src` { #preset-property-suffix_icon-src }
 
 Specify the URL of an SVG file to use as the icon. Be sure you trust the content you are including, as it will be
 executed as code and can result in XSS attacks.
+
+If you specify this option, Platen ignores the values for `name`, `variant`, and `library` for the icon.
+
+#### `variant` { #preset-property-suffix_icon-variant }
+
+Specify the variant of the icon to use. Not all icons and libraries support variants. When you don't specify a variant,
+Platen uses the library's default variant.
 
 #### Other Attributes
 
@@ -1087,7 +1259,7 @@ it will become the default. Eventually, the legacy template will be removed enti
 
 ``````details
 ---
-summary: Details SCSS
+summary: Buttons SCSS
 heading_level: 3
 ---
 
@@ -1175,6 +1347,7 @@ the name for the style module `assets/styles/markup/_foo.scss` is `foo`.
 
 <!-- Link References -->
 [sref:`<sl-button>`]: sl.component:button
+[sref:`<sl-icon>`]: sl.component:icon
 [sref:Shoelace]: sl:
 [s01]: mdn.html.element:a
 [s02]: mdn.html.element:a#attr-href

--- a/modules/platen/_docs/markup/details/index.md
+++ b/modules/platen/_docs/markup/details/index.md
@@ -95,7 +95,7 @@ You can use any valid Markdown, including:
 ```
 ``````
 
-``````memo-example-renderer { title="Attribute Parameter Example" }
+``````memo-example-renderer { title="Attributes Example" }
 This example adds the `info` class to the details element and sets a specific
 summary.
 
@@ -109,11 +109,23 @@ Another _Markdown_ example.
 ```
 ``````
 
-`````````memo-example-renderer { title="YAML Options Parameter Example" }
+`````````memo-example-renderer { title="YAML Options Example" }
 This example ensures the block is loaded in its collapsed state instead of open
 and sets the `heading_level` option to `4`. That ensures Platen writes the
 summary inside an `<h4>` element, meaning the details block can show up in the
 table of contents.
+
+The example also sets the [`open` option](#option-open) to `false`, so the
+details element is loaded in the collapsed state.
+
+The example sets both the [`icon_collapse`](#option-icon_collapse) and
+[`icon_expand`](#option-icon_expand) options. When these are both set, the
+details are rendered with the specified icons to show that the block can be
+collapsed or expanded.
+
+The `icon_collapse` option shows the shorthand definition for an icon in
+Platen. The `icon_expand` option shows the extended definition for an icon.
+For more information, see the documentation for these options.
 
 Note that this example also uses more backticks (`` ` ``) for the codeblock.
 That lets you include nested codeblocks inside the details. Here it's used to
@@ -125,8 +137,10 @@ add a [mermaid diagram](mermaid.md).
 summary:       Heading Summary with Nested Codeblock
 heading_level: 4
 open:          false
-icon_collapse: dash-square
-icon_expand:   plus-square
+icon_collapse: minus-square@lucide
+icon_expand:
+  name: plus-square
+  library: lucide
 ---
 
 Check out this neat diagram:
@@ -230,9 +244,11 @@ When this value is greater than `6`, it's treated as `6`.
 
 ### `icon_collapse` { #option-icon_collapse }
 
-Specify a [sref:valid icon][06] to use to when the details element is open, indicating that the element can be
-collapsed. By default, Platen uses a rotating caret instead of an icon. If you specify a value for this option, you
-must also specify a value for [`icon_expand`](#option-icon_expand).
+Specify an icon to use to when the details element is expanded, indicating that the element can be collapsed. By
+default, Platen uses a rotating caret instead of an icon. If you specify a value for this option, you must also specify
+a value for [`icon_expand`](#option-icon_expand).
+
+You can specify the icon either as a string using the shorthand syntax or as a map of options for the icon.
 
 You can also define the default icons for your details elements with the `platen.markup.details.icons` settings for
 your site configuration. Values from your site configuration are overridden by this option in your markup. For more
@@ -242,11 +258,40 @@ This option isn't valid with the [legacy details](#legacy-template).
 
 {{< memo/renderer/option "icon_collapse" >}}
 
+#### Shorthand Syntax { #option-icon_collapse-shorthand-syntax }
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support variants. When
+  you specify a variant in this syntax, you must specify it after the icon's name. You must separate the variant from
+  the icon name with an ampersand (`&`). When you don't specify a variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When you specify a library in this syntax,
+  you must specify it after the icon's name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the configured default library.
+
+You can find the [sref:list of available icons in the default library in Shoelace's documentation][06]
+
+#### Options Syntax { #option-icon_collapse-options-syntax }
+
+The options syntax for icons is:
+
+```yaml
+name:    icon_name    # Mandatory
+library: icon_library # Optional
+variant: icon_variant # Optional
+```
+
+You can also pass any valid [sref:global HTML attribute][07] in the options map for the icon, like `class` or `style`.
+Those attributes are passed through to the icon element.
+
 ### `icon_expand` { #option-icon_expand }
 
-Specify a [sref:valid icon][06] to use to when the details element is closed, indicating that the element can be
-expanded. By default, Platen uses a rotating caret instead of an icon. If you specify a value for this option, you must
-also specify a value for [`icon_collapse`](#option-icon_collapse).
+Specify an icon to use to when the details element is closed, indicating that the element can be expanded. By default,
+Platen uses a rotating caret instead of an icon. If you specify a value for this option, you must also specify a value
+for [`icon_collapse`](#option-icon_collapse).
+
+You can specify the icon either as a string using the shorthand syntax or as a map of options for the icon.
 
 You can also define the default icons for your details elements with the `platen.markup.details.icons` settings for
 your site configuration. Values from your site configuration are overridden by this option in your markup. For more
@@ -255,6 +300,33 @@ information, see [Configuration](#configuration).
 This option isn't valid with the [legacy details](#legacy-template).
 
 {{< memo/renderer/option "icon_expand" >}}
+
+#### Shorthand Syntax { #option-icon_expand-shorthand-syntax }
+
+The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+- `<name>` is mandatory and represents the name of the icon.
+- `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support variants. When
+  you specify a variant in this syntax, you must specify it after the icon's name. You must separate the variant from
+  the icon name with an ampersand (`&`). When you don't specify a variant, Platen uses the library's default variant.
+- `&<library>` is optional and represents the library the icon belongs to. When you specify a library in this syntax,
+  you must specify it after the icon's name and variant. You must separate the library from the icon name or variant
+  with an at sign (`@`). When you don't specify a library, Platen uses the configured default library.
+
+You can find the [sref:list of available icons in the default library in Shoelace's documentation][06]
+
+#### Options Syntax { #option-icon_expand-options-syntax }
+
+The options syntax for icons is:
+
+```yaml
+name:    icon_name    # Mandatory
+library: icon_library # Optional
+variant: icon_variant # Optional
+```
+
+You can also pass any valid [sref:global HTML attribute][07] in the options map for the icon, like `class` or `style`.
+Those attributes are passed through to the icon element.
 
 ### `id` { #option-id }
 
@@ -572,6 +644,7 @@ the name for the style module `assets/styles/markup/_foo.scss` is `foo`.
 [04]: mdn.html.global_attribute:class
 [05]: mdn.html.element:Heading_Elements
 [06]: sl.component:icon?id=default-icons
+[07]: mdn.html.global_attribute:
 [sref:`<sl-details>`]: sl.component:details
 [sref:`<sl-icon>`]: sl.component:icon
 [sref:Shoelace]: sl:

--- a/modules/platen/_schema_data/schemas/platen/site/config.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/config.yaml
@@ -45,6 +45,10 @@ properties:
         $ref: ./features/search.yaml
         schematize:
           weight: 4
+      shoelace:
+        $ref: ./features/shoelace/options.yaml
+        schematize:
+          weight: 5
     patternProperties:
       ".":
         $ref: ./features/defining.yaml

--- a/modules/platen/_schema_data/schemas/platen/site/display/footer.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/display/footer.yaml
@@ -1,0 +1,277 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: footer.schema.yaml
+title: Site Footer Display Settings
+description: Controls the rendering of the header element for site pages
+schematize:
+  weight: 2
+  skip_schema_render: true
+  details: |
+    Controls the rendering of the footer element for site pages. By default, every page is rendered with a footer
+    element that includes information about when the page was last updated and links to the last update and where a
+    reader can submit edits for the page.
+type: object
+properties:
+  edit_this_page:
+    title: Edit This Page Button Link
+    description: Controls the button linking to where a user can submit edits for the current page.
+    schematize:
+      weight: 1
+      details: |
+        These settings control the "edit this page" button Platen adds to the footer of every page. The button links
+        to the source control web page for editing the current page. You can disable this link by setting `enabled` to
+        `false`.
+    type: object
+    properties:
+      enabled:
+        title: Enable Button Link
+        description: Choose whether to enable the button link.
+        schematize:
+          weight: 1
+          details: |
+            Use this setting to choose whether the button link should display in the page's footer. When you set this
+            value to `true`, the button link is added to the footer. When you set this value to `false`, the button
+            link is ignored during the page render.
+        type: boolean
+        default: true
+      prefix_icon:
+        title: Prefix Icon
+        description: Controls the prefix icon for the button link.
+        schematize:
+          weight: 2
+          details: |
+            Use these options to control the icon used for the button link. By default, Platen displays a pencil icon
+            for the edit this page button link.
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            title: Icon Name
+            description: Specify the name of the icon to use.
+            schematize: 
+              weight: 1
+              details: |
+                Specify the name of the icon to use for the button link. You can use the shorthand syntax for this
+                value instead of specifying values for the `library` and `variant` options.
+
+                The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+                - `<name>` is mandatory and represents the name of the icon.
+                - `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support
+                  variants. When you specify a variant in this syntax, you must specify it after the icon's name. You
+                  must separate the variant from the icon name with an ampersand (`&`). When you don't specify a
+                  variant, Platen uses the library's default variant.
+                - `&<library>` is optional and represents the library the icon belongs to. When you specify a library
+                  in this syntax, you must specify it after the icon's name and variant. You must separate the library
+                  from the icon name or variant with an at sign (`@`). When you don't specify a library, Platen uses
+                  the configured default library.
+            type: string
+            default: calendar-fill@builtin_bootstrap
+          library:
+            title: Icon Library
+            description: The library the icon is in.
+            schematize:
+              weight: 2
+              details: |
+                This setting specifies the library to load the icon from. You can use any of the registered icon
+                libraries. If you don't specify a value for this setting, Platen uses the
+                `features.shoelace.icons.default_library` setting's value as the library.
+
+                Don't specify this setting if you're including the library in the `name` setting with the shorthand
+                syntax.
+            oneOf:
+              - enum:
+                - builtin_bootstrap
+                - boxicons
+                - font_awesome
+                - heroicons
+                - iconoir
+                - ionicons
+                - jam_icons
+                - lucide
+                - material_icons
+                - remix_icon
+                - tabler_icons
+                - unicons
+              - type: string
+          variant:
+            title: Icon Variant
+            description: The icon variant.
+            schematize:
+              weight: 3
+              details: |
+                This setting specifies the icon's variant. Not all icons and libraries have variants. If this value
+                isn't set, the icon uses its default variant.
+
+                Don't specify this setting if you're including the variant in the `name` setting with the shorthand
+                syntax.
+            type: string
+      variant:
+        title: Button Variant
+        description: Choose the variant for the button link.
+        schematize:
+          weight: 3
+          details: |
+            Choose the variant for the button link. This controls how the button looks on the site.
+        type: string
+        enum:
+          - default
+          - primary
+          - success
+          - neutral
+          - warning
+          - danger
+          - text
+        default: text
+      show_elapsed:
+        title: Show Elapsed Time
+        description: Choose whether to display the elapsed time since or date of last change to the page.
+        schematize:
+          weight: 4
+          details: |
+            Blah.
+        type: boolean
+        default: true
+      use_legacy:
+        title: Use Legacy Link
+        description: Choose whether to use the legacy link or the configurable Shoelace button link.
+        schematize:
+          weight: 99
+          details: |
+            Use this setting to choose whether to use the legacy implementation for the "edit this page" footer link.
+            The current default value is `true`, which renders the old SVG icon and fixed link text, and ignores all
+            other settings for the control.
+            
+            In the future, the default value will change to `false`. Later, this setting will be removed and only the
+            new implementation will be available. We strongly recommend you update this setting to `false` and adjust
+            your site's theme as needed.
+        type: boolean
+        default: true
+  last_edited_on:
+    title: Last Edited On Button Link
+    description: Controls the button linking to the last change for the current page.
+    schematize:
+      weight: 1
+      details: |
+        These settings control the "last edited on" button Platen adds to the footer of every page. The button links to
+        the source control web page for the last commit to the current page. You can disable this link by setting
+        `enabled` to `false`.
+    type: object
+    properties:
+      enabled:
+        title: Enable Button Link
+        description: Choose whether to enable the button link.
+        schematize:
+          weight: 1
+          details: |
+            Use this setting to choose whether the button link should display in the page's footer. When you set this
+            value to `true`, the button link is added to the footer. When you set this value to `false`, the button
+            link is ignored during the page render.
+        type: boolean
+        default: true
+      prefix_icon:
+        title: Prefix Icon
+        description: Controls the prefix icon for the button link.
+        schematize:
+          weight: 2
+          details: |
+            Use these options to control the icon used for the button link. By default, Platen displays a calendar icon
+            for the last edited on button link.
+        type: object
+        required:
+          - name
+        properties:
+          name:
+            title: Icon Name
+            description: Specify the name of the icon to use.
+            schematize: 
+              weight: 1
+              details: |
+                Specify the name of the icon to use for the button link. You can use the shorthand syntax for this
+                value instead of specifying values for the `library` and `variant` options.
+
+                The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+                - `<name>` is mandatory and represents the name of the icon.
+                - `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support
+                  variants. When you specify a variant in this syntax, you must specify it after the icon's name. You
+                  must separate the variant from the icon name with an ampersand (`&`). When you don't specify a
+                  variant, Platen uses the library's default variant.
+                - `&<library>` is optional and represents the library the icon belongs to. When you specify a library
+                  in this syntax, you must specify it after the icon's name and variant. You must separate the library
+                  from the icon name or variant with an at sign (`@`). When you don't specify a library, Platen uses
+                  the configured default library.
+            type: string
+            default: calendar-fill@builtin_bootstrap
+          library:
+            title: Icon Library
+            description: The library the icon is in.
+            schematize:
+              weight: 2
+              details: |
+                This setting specifies the library to load the icon from. You can use any of the registered icon
+                libraries. If you don't specify a value for this setting, Platen uses the
+                `features.shoelace.icons.default_library` setting's value as the library.
+
+                Don't specify this setting if you're including the library in the `name` setting with the shorthand
+                syntax.
+            oneOf:
+              - enum:
+                - builtin_bootstrap
+                - boxicons
+                - font_awesome
+                - heroicons
+                - iconoir
+                - ionicons
+                - jam_icons
+                - lucide
+                - material_icons
+                - remix_icon
+                - tabler_icons
+                - unicons
+              - type: string
+          variant:
+            title: Icon Variant
+            description: The icon variant.
+            schematize:
+              weight: 3
+              details: |
+                This setting specifies the icon's variant. Not all icons and libraries have variants. If this value
+                isn't set, the icon uses its default variant.
+
+                Don't specify this setting if you're including the variant in the `name` setting with the shorthand
+                syntax.
+            type: string
+      variant:
+        title: Button Variant
+        description: Choose the variant for the button link.
+        schematize:
+          weight: 3
+          details: |
+            Choose the variant for the button link. This controls how the button looks on the site.
+        type: string
+        enum:
+          - default
+          - primary
+          - success
+          - neutral
+          - warning
+          - danger
+          - text
+        default: text
+      use_legacy:
+        title: Use Legacy Link
+        description: Choose whether to use the legacy link.
+        schematize:
+          weight: 99
+          details: |
+            Use this setting to choose whether to use the legacy implementation for the "last edited on" footer link.
+            The current default value is `true`, which renders the old SVG icon and fixed link text, and ignores all
+            other settings for the control.
+            
+            In the future, the default value will change to `false`. Later, this setting will be removed and only the
+            new implementation will be available. We strongly recommend you update this setting to `false` and adjust
+            your site's theme as needed.
+        type: boolean
+        default: true

--- a/modules/platen/_schema_data/schemas/platen/site/display/menu/settings.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/display/menu/settings.yaml
@@ -61,12 +61,116 @@ properties:
         [sref:section]: platen.content.section.menu.hide
     type: string
     default: /
+  languages_icon:
+    title: Languages Icon
+    description: Defines the options for the languages icon for selecting translations in a multilingual site.
+    schematize:
+      weight: 2
+      details: |
+        This setting defines the options for the languages icon that displays on multilingual sites. The icon displays
+        beside the language of the current page in the dropdown entry. When you select the component in the menu,
+        Platen displays the list of translations for the current page.
+    type: object
+    properties:
+      name:
+        title: Icon Name
+        description: The name of the icon.
+        schematize:
+          weight: 1
+          details: |
+            This setting specifies the name of the icon to display. You can specify the icon with Platen's shorthand
+            syntax for icons.
+
+            The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+            - `<name>` is mandatory and represents the name of the icon.
+            - `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support
+              variants. When you specify a variant in this syntax, you must specify it after the icon's name. You must
+              separate the variant from the icon name with an ampersand (`&`). When you don't specify a variant, Platen
+              uses the library's default variant.
+            - `&<library>` is optional and represents the library the icon belongs to. When you specify a library in
+              this syntax, you must specify it after the icon's name and variant. You must separate the library from
+              the icon name or variant with an at sign (`@`). When you don't specify a library, Platen uses the
+              configured default library.
+
+            You can always use [sref:any valid icon] in Shoelace's default icon library.
+
+            If you specify the icon's variant or library with the shorthand syntax, don't specify the [sref:`variant`]
+            or [sref:`library`] settings for this icon.
+
+            The default icon for this setting is: ![icon:translate][default]
+
+            [sref:any valid icon]: sl.component:icon?default-icons
+            [default]: builtin_bootstrap "The 'translate' icon from the builtin bootstrap icon library from Shoelace."
+        type: string
+        default: translate@builtin_bootstrap
+      library:
+        title: Icon Library
+        description: The library the icon is in.
+        schematize:
+          weight: 2
+          details: |
+            This setting specifies the library to load the icon from. You can use any of the registered icon libraries.
+            If you don't specify a value for this setting, Platen uses the `features.shoelace.icons.default_library`
+            setting's value as the library.
+
+            Don't specify this setting if you're including the library in the `name` setting with the shorthand syntax.
+        oneOf:
+          - enum:
+            - builtin_bootstrap
+            - boxicons
+            - font_awesome
+            - heroicons
+            - iconoir
+            - ionicons
+            - jam_icons
+            - lucide
+            - material_icons
+            - remix_icon
+            - tabler_icons
+            - unicons
+          - type: string
+      variant:
+        title: Icon Variant
+        description: The icon variant.
+        schematize:
+          weight: 3
+          details: |
+            This setting specifies the icon's variant. Not all icons and libraries have variants. If this value isn't
+            set, the icon uses its default variant.
+
+            Don't specify this setting if you're including the variant in the `name` setting with the shorthand syntax.
+        type: string
+      src:
+        title: Icon SVG Source
+        description: The source for a custom icon.
+        schematize:
+          weight: 4
+          details: |
+            This setting specifies the URL to an SVG file to use as a custom icon. If you specify this value, Platen
+            ignores the settings for the `name`, `library`, and `variant` settings.
+        type: string
+      use_legacy:
+        title: Use Legacy Languages Icon
+        description: Choose whether to use the legacy SVG icon or the configurable shoelace icon.
+        schematize:
+          weight: 99
+          details: |
+            Use this setting to choose whether to use the legacy implementation for the languages icon. The current
+            default value is `true`, which renders the default icon and ignores all other settings for the language
+            icon.
+            
+            In the future, the default value will change to `false`. Later, this setting will be removed and only the
+            new implementation will be available. We strongly recommend you update this setting to `false` and adjust
+            your site's theme as needed.
+        type: boolean
+        default: true
   before_injection:
     title: Feature Entries Before Menu Injection 
     description: Define entries at the beginning of the site menu.
     type: object
     schematize:
-      weight: 2
+      weight: 90
       skip_schema_render: true
       details: |
         This setting allows you to add menu entries for the feature at the very top of the site
@@ -114,7 +218,7 @@ properties:
     description: Define feature menu entries after injection and before configured entries.
     type: object
     schematize:
-      weight: 3
+      weight: 91
       skip_schema_render: true
       details: |
         This setting allows you to add menu entries for the feature after any from the injection
@@ -163,7 +267,7 @@ properties:
     description: Define feature menu entries after configured entries and before automatic ones.
     type: object
     schematize:
-      weight: 4
+      weight: 92
       skip_schema_render: true
       details: |
         This setting allows you to add menu entries for the feature after the entries from the
@@ -212,7 +316,7 @@ properties:
     description: Define feature menu entries after automatic entries and before configured ones.
     type: object
     schematize:
-      weight: 5
+      weight: 93
       skip_schema_render: true
       details: |
         This setting allows you to add menu entries for the feature after the content added from
@@ -261,7 +365,7 @@ properties:
     description: Define feature menu entries after configured entries and before injection.
     type: object
     schematize:
-      weight: 6
+      weight: 94
       skip_schema_render: true
       details: |
         This setting allows you to add menu entries for the feature after the entries from the
@@ -309,7 +413,7 @@ properties:
     description: Define feature menu entries at the end of the site menu.
     type: object
     schematize:
-      weight: 7
+      weight: 95
       skip_schema_render: true
       details: |
         This setting allows you to add menu entries for the feature at the very bottom of the

--- a/modules/platen/_schema_data/schemas/platen/site/display/mobile.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/display/mobile.yaml
@@ -1,0 +1,450 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: mobile.schema.yaml
+title: Site Mobile Display Settings
+description: Optional settings controlling how a Platen mobile view displays.
+schematize:
+  details: |
+    The Platen display options control how the site displays on smaller screens.
+type: object
+properties:
+  menu_control:
+    title: Menu Control Button
+    description: Controls the display for the button that shows the site menu on mobile.
+    schematize:
+      weight: 1
+      details: |
+        Use these settings to control the display for the button that shows the site menu on mobile. The button appears
+        in the top left corner of each page beside the page's title. When a visitor clicks it, the site menu pops out
+        from the left side of the screen.
+
+        At this time, the `use_legacy` setting for this control defaults to `true`, which makes Platen render your site
+        with the old control. The old control is not configurable. In the future, the default value for this control
+        will be updated to `false`. Later, the option to use the legacy control will be removed entirely.
+
+        We strongly recommend that you set `use_legacy` to `false` and update your site's theme as needed.
+    type: object
+    properties:
+      name:
+        title: Icon Name
+        description: The name of the icon.
+        schematize:
+          weight: 1
+          details: |
+            This setting specifies the name of the icon to display. You can specify the icon with Platen's shorthand
+            syntax for icons.
+
+            The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+            - `<name>` is mandatory and represents the name of the icon.
+            - `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support
+              variants. When you specify a variant in this syntax, you must specify it after the icon's name. You must
+              separate the variant from the icon name with an ampersand (`&`). When you don't specify a variant, Platen
+              uses the library's default variant.
+            - `&<library>` is optional and represents the library the icon belongs to. When you specify a library in
+              this syntax, you must specify it after the icon's name and variant. You must separate the library from
+              the icon name or variant with an at sign (`@`). When you don't specify a library, Platen uses the
+              configured default library.
+
+            You can always use [sref:any valid icon] in Shoelace's default icon library.
+
+            If you specify the icon's variant or library with the shorthand syntax, don't specify the [sref:`variant`]
+            or [sref:`library`] settings for this icon.
+
+            The default icon for this setting is: ![icon:list][default]
+
+            [sref:any valid icon]: sl.component:icon?default-icons
+            [default]: builtin_bootstrap "The 'list' icon from the builtin bootstrap icon library from Shoelace."
+        type: string
+        default: list@builtin_bootstrap
+      label:
+        title: Icon Button Label
+        description: Defines the accessible label for the icon button.
+        schematize:
+          weight: 2
+          details: |
+            This setting defines the accessible label for the icon button. A label helps users understand what a button
+            without text does.
+
+            Specify a short plaintext message explaining what the button does. If you specify this value with the
+            prefix `i18n!`, like `i18n!foo_bar`, Platen looks up the value as a key in your site's internationalization
+            settings to translate the value for the current language. This can help make your buttons more accessible
+            for multilingual sites.
+        type: string
+        default: i18n!menu_control
+      library:
+        title: Icon Library
+        description: The library the icon is in.
+        schematize:
+          weight: 3
+          details: |
+            This setting specifies the library to load the icon from. You can use any of the registered icon libraries.
+            If you don't specify a value for this setting, Platen uses the `features.shoelace.icons.default_library`
+            setting's value as the library.
+
+            Don't specify this setting if you're including the library in the `name` setting with the shorthand syntax.
+        oneOf:
+          - enum:
+            - builtin_bootstrap
+            - boxicons
+            - font_awesome
+            - heroicons
+            - iconoir
+            - ionicons
+            - jam_icons
+            - lucide
+            - material_icons
+            - remix_icon
+            - tabler_icons
+            - unicons
+          - type: string
+      variant:
+        title: Icon Variant
+        description: The icon variant.
+        schematize:
+          weight: 3
+          details: |
+            This setting specifies the icon's variant. Not all icons and libraries have variants. If this value isn't
+            set, the icon uses its default variant.
+
+            Don't specify this setting if you're including the variant in the `name` setting with the shorthand syntax.
+        type: string
+      src:
+        title: Icon SVG Source
+        description: The source for a custom icon.
+        schematize:
+          weight: 4
+          details: |
+            This setting specifies the URL to an SVG file to use as a custom icon. If you specify this value, Platen
+            ignores the settings for the `name`, `library`, and `variant` settings.
+        type: string
+      classes:
+        title: Icon Button Classes
+        description: One or more CSS classes to add to the button.
+        schematize:
+          weight: 6
+          details: |
+            Use this setting to add CSS classes to the icon button. These classes can control how the icon is styled on
+            the site separately from the configuration options.
+        type: array
+        items:
+          type: string
+      tooltip:
+        title: Tooltip Options
+        description: Set options for the icon button's tooltip.
+        schematize:
+          weight: 7
+          details: |
+            Use these settings to control how the icon button's tooltip displays. Icon buttons always have a tooltip to
+            help make their usage more obvious to readers.
+        type: object
+        properties:
+          classes:
+            title: Tooltip Classes
+            description: One or more CSS classes to add to the tooltip.
+            schematize:
+              weight: 1
+              details: |
+                Use this setting to add CSS classes to the tooltip. These classes can control how the tooltip is styled
+                on the site separately from the configuration options.
+            type: array
+            items:
+              type: string
+          content:
+            title: Tooltip Content
+            description: The text to display for the tooltip.
+            schematize:
+              weight: 2
+              details: |
+                Use this setting to define a custom message to display for the tooltip. If this value isn't defined,
+                the tooltip displays the label text for the icon button.
+
+                If you specify this value with the prefix `i18n!`, like `i18n!foo_bar`, Platen looks up the value as a
+                key in your site's internationalization settings to translate the value for the current language. This
+                can help make your tooltips more accessible for multilingual sites.
+            type: string
+          placement:
+            title: Tooltip Placement
+            description: Where the tooltip renders in relation to the icon button.
+            schematize:
+              weight: 3
+              details: |
+                Use this setting to define where the tooltip pops up in relation to the icon button.
+                
+                The `top`, `right`, `bottom`, and `left` placements indicate whether the tooltip should appear directly
+                above, to the right of, beneath, or to the left of the button respectively. The `-start` and `-end`
+                suffixes shift the placement away from the centerline.
+
+                For example, the `top` placement is directly above the inside content and centered on it, but `top-end`
+                appears from the top right corner of the inside content for left-to-right languages like English.
+            enum:
+              - top
+              - top-start
+              - top-end
+              - right
+              - right-start
+              - right-end
+              - bottom
+              - bottom-start
+              - bottom-end
+              - left
+              - left-start
+              - left-end
+            default: right
+          distance:
+            title: Tooltip Distance
+            description: Sets how many pixels away from the icon button the tooltip renders.
+            schematize:
+              weight: 4
+              details: |
+                Use this setting to determine how many pixels away from the icon button the tooltip renders when
+                active.
+
+                The default value in Shoelace is `8` pixels.
+            type: integer
+            minimum: 0
+          skidding:
+            title: Tooltip Skidding
+            description: Sets how many pixels to offset the tooltip from its defined placement along the icon button.
+            schematize:
+              weight: 5
+              details: |
+                Use this setting to determine how many pixels from the defined placement the tooltip renders along the
+                icon. This shifts the tooltip along the cross-axis from the `distance` setting.
+
+                The default value in Shoelace is `0` pixels.
+            type: integer
+      use_legacy:
+        title: Use Legacy Menu Control
+        description: Choose whether to use the legacy SVG icon control or the configurable shoelace icon button.
+        schematize:
+          weight: 99
+          details: |
+            Use this setting to choose whether to use the legacy implementation for the mobile menu control. The current
+            default value is `true`, which renders the old SVG icon and ignores all other settings for the control.
+            
+            In the future, the default value will change to `false`. Later, this setting will be removed and only the
+            new implementation will be available. We strongly recommend you update this setting to `false` and adjust
+            your site's theme as needed.
+        type: boolean
+        default: true
+  toc_control:
+    title: Table of Contents Control Button
+    description: Controls the display for the button that shows the TOC on mobile.
+    schematize:
+      weight: 1
+      details: |
+        Use these settings to control the display for the button that shows the table of contents on mobile. The button
+        appears in the top right corner of each page beside the page's title. When a visitor clicks it, the table of
+        contents pops out from the right side of the screen.
+
+        At this time, the `use_legacy` setting for this control defaults to `true`, which makes Platen render your site
+        with the old control. The old control is not configurable. In the future, the default value for this control
+        will be updated to `false`. Later, the option to use the legacy control will be removed entirely.
+
+        We strongly recommend that you set `use_legacy` to `false` and update your site's theme as needed.
+    type: object
+    properties:
+      name:
+        title: Icon Name
+        description: The name of the icon.
+        schematize:
+          weight: 1
+          details: |
+            This setting specifies the name of the icon to display. You can specify the icon with Platen's shorthand
+            syntax for icons.
+
+            The shorthand syntax for icons in Platen is `<name>[&<variant>][@<library>]`, where:
+
+            - `<name>` is mandatory and represents the name of the icon.
+            - `&<variant>` is optional and represents the variant of the icon. Not all icons and libraries support
+              variants. When you specify a variant in this syntax, you must specify it after the icon's name. You must
+              separate the variant from the icon name with an ampersand (`&`). When you don't specify a variant, Platen
+              uses the library's default variant.
+            - `&<library>` is optional and represents the library the icon belongs to. When you specify a library in
+              this syntax, you must specify it after the icon's name and variant. You must separate the library from
+              the icon name or variant with an at sign (`@`). When you don't specify a library, Platen uses the
+              configured default library.
+
+            You can always use [sref:any valid icon] in Shoelace's default icon library.
+
+            If you specify the icon's variant or library with the shorthand syntax, don't specify the [sref:`variant`]
+            or [sref:`library`] settings for this icon.
+
+            The default icon for this setting is: ![icon:list-columns][default]
+
+            [sref:any valid icon]: sl.component:icon?default-icons
+            [default]: builtin_bootstrap "The 'list-columns' icon from the builtin bootstrap icon library from Shoelace."
+        type: string
+        default: list-columns@builtin_bootstrap
+      label:
+        title: Icon Button Label
+        description: Defines the accessible label for the icon button.
+        schematize:
+          weight: 2
+          details: |
+            This setting defines the accessible label for the icon button. A label helps users understand what a button
+            without text does.
+
+            Specify a short plaintext message explaining what the button does. If you specify this value with the
+            prefix `i18n!`, like `i18n!foo_bar`, Platen looks up the value as a key in your site's internationalization
+            settings to translate the value for the current language. This can help make your buttons more accessible
+            for multilingual sites.
+        type: string
+        default: i18n!toc_control
+      library:
+        title: Icon Library
+        description: The library the icon is in.
+        schematize:
+          weight: 3
+          details: |
+            This setting specifies the library to load the icon from. You can use any of the registered icon libraries.
+            If you don't specify a value for this setting, Platen uses the `features.shoelace.icons.default_library`
+            setting's value as the library.
+
+            Don't specify this setting if you're including the library in the `name` setting with the shorthand syntax.
+        oneOf:
+          - enum:
+            - builtin_bootstrap
+            - boxicons
+            - font_awesome
+            - heroicons
+            - iconoir
+            - ionicons
+            - jam_icons
+            - lucide
+            - material_icons
+            - remix_icon
+            - tabler_icons
+            - unicons
+          - type: string
+      variant:
+        title: Icon Variant
+        description: The icon variant.
+        schematize:
+          weight: 3
+          details: |
+            This setting specifies the icon's variant. Not all icons and libraries have variants. If this value isn't
+            set, the icon uses its default variant.
+
+            Don't specify this setting if you're including the variant in the `name` setting with the shorthand syntax.
+        type: string
+      src:
+        title: Icon SVG Source
+        description: The source for a custom icon.
+        schematize:
+          weight: 4
+          details: |
+            This setting specifies the URL to an SVG file to use as a custom icon. If you specify this value, Platen
+            ignores the settings for the `name`, `library`, and `variant` settings.
+        type: string
+      classes:
+        title: Icon Button Classes
+        description: One or more CSS classes to add to the button.
+        schematize:
+          weight: 6
+          details: |
+            Use this setting to add CSS classes to the icon button. These classes can control how the icon is styled on
+            the site separately from the configuration options.
+        type: array
+        items:
+          type: string
+      tooltip:
+        title: Tooltip Options
+        description: Set options for the icon button's tooltip.
+        schematize:
+          weight: 7
+          details: |
+            Use these settings to control how the icon button's tooltip displays. Icon buttons always have a tooltip to
+            help make their usage more obvious to readers.
+        type: object
+        properties:
+          classes:
+            title: Tooltip Classes
+            description: One or more CSS classes to add to the tooltip.
+            schematize:
+              weight: 1
+              details: |
+                Use this setting to add CSS classes to the tooltip. These classes can control how the tooltip is styled
+                on the site separately from the configuration options.
+            type: array
+            items:
+              type: string
+          content:
+            title: Tooltip Content
+            description: The text to display for the tooltip.
+            schematize:
+              weight: 2
+              details: |
+                Use this setting to define a custom message to display for the tooltip. If this value isn't defined,
+                the tooltip displays the label text for the icon button.
+
+                If you specify this value with the prefix `i18n!`, like `i18n!foo_bar`, Platen looks up the value as a
+                key in your site's internationalization settings to translate the value for the current language. This
+                can help make your tooltips more accessible for multilingual sites.
+            type: string
+          placement:
+            title: Tooltip Placement
+            description: Where the tooltip renders in relation to the icon button.
+            schematize:
+              weight: 3
+              details: |
+                Use this setting to define where the tooltip pops up in relation to the icon button.
+                
+                The `top`, `right`, `bottom`, and `left` placements indicate whether the tooltip should appear directly
+                above, to the right of, beneath, or to the left of the button respectively. The `-start` and `-end`
+                suffixes shift the placement away from the centerline.
+
+                For example, the `top` placement is directly above the inside content and centered on it, but `top-end`
+                appears from the top right corner of the inside content for left-to-right languages like English.
+            enum:
+              - top
+              - top-start
+              - top-end
+              - right
+              - right-start
+              - right-end
+              - bottom
+              - bottom-start
+              - bottom-end
+              - left
+              - left-start
+              - left-end
+            default: left
+          distance:
+            title: Tooltip Distance
+            description: Sets how many pixels away from the icon button the tooltip renders.
+            schematize:
+              weight: 4
+              details: |
+                Use this setting to determine how many pixels away from the icon button the tooltip renders when
+                active.
+
+                The default value in Shoelace is `8` pixels.
+            type: integer
+            minimum: 0
+          skidding:
+            title: Tooltip Skidding
+            description: Sets how many pixels to offset the tooltip from its defined placement along the icon button.
+            schematize:
+              weight: 5
+              details: |
+                Use this setting to determine how many pixels from the defined placement the tooltip renders along the
+                icon. This shifts the tooltip along the cross-axis from the `distance` setting.
+
+                The default value in Shoelace is `0` pixels.
+            type: integer
+      use_legacy:
+        title: Use Legacy Table of Contents Control
+        description: Choose whether to use the legacy SVG icon control or the configurable shoelace icon button.
+        schematize:
+          weight: 99
+          details: |
+            Use this setting to choose whether to use the legacy implementation for the mobile menu control. The current
+            default value is `true`, which renders the old SVG icon and ignores all other settings for the control.
+            
+            In the future, the default value will change to `false`. Later, this setting will be removed and only the
+            new implementation will be available. We strongly recommend you update this setting to `false` and adjust
+            your site's theme as needed.
+        type: boolean
+        default: true

--- a/modules/platen/_schema_data/schemas/platen/site/display/settings.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/display/settings.yaml
@@ -97,11 +97,16 @@ properties:
     $ref: ./menu/settings.yaml
     schematize:
       weight: 4
+  mobile:
+    $ref: ./mobile.yaml
+    schematize:
+      weight: 5
+      skip_schema_render: true
   section_classes:
     title: Extra CSS Classes for Sections
     description: Adds CSS classes to sections by URL prefix
     schematize:
-      weight: 5
+      weight: 6
       skip_schema_render: true
       details: |
         Defines a set of sections and the CSS classes to inject in the `body` element for every page
@@ -149,7 +154,7 @@ properties:
     title: Table of Contents
     description: Controls the rendering of the table of contents for site pages.
     schematize:
-      weight: 6
+      weight: 7
       skip_schema_render: true
       details: |
         Controls the rendering of the table of contents for site pages. You can choose whether to

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/boxicons.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/boxicons.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: boxicons.schema.yaml
+title: Boxicons
+description: Settings for the Boxicons library.
+schematize:
+  weight: 2
+  details: |
+    These options control the registration of the [Boxicons][01] library.
+
+    ```alert
+    Boxicons uses the [Creative Commons 4.0 License](https://github.com/atisawd/boxicons#license).
+    ```
+
+    [01]: https://boxicons.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - box
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 2.0.5
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 4
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - regular
+      - solid
+      - logos
+    default: regular
+  variants:
+    title: Library Variants Map
+    description: Maps a friendly variant name to the icon's prefix.
+    schematize:
+      weight: 5
+      details: |
+        Use this option to create a map of friendly names for icon variants to generate their final icon
+        name to retrieve from the library.
+    type: object
+    properties:
+      regular:
+        title: Regular Variant
+        description: Maps the variant name `regular` for boxicons.
+        type: string
+        default: bx
+      solid:
+        title: Solid Variant
+        description: Maps the variant name `solid` for boxicons.
+        type: string
+        default: bxs
+      logos:
+        title: Logos Variant
+        description: Maps the variant name `logos` for boxicons.
+        type: string
+        default: bxl
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: boxicons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/default.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/default.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: default.schema.yaml
+title: Builtin Bootstrap Icons Library
+description: Settings for the builtin icons library.
+schematize:
+  weight: 1
+  details: |
+    These options control the default icon library used by Shoelace. Shoelace makes 1,500 icons from the
+    [Bootstrap Icons][01] project available.
+
+    [01]: https://icons.getbootstrap.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library
+    schematize:
+      weight: 99
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default: []

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/font_awesome.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/font_awesome.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: font_awesome.schema.yaml
+title: Font Awesome
+description: Settings for the Font Awesome icons library.
+schematize:
+  weight: 3
+  details: |
+    These options control the registration of the [Font Awesome free][01] library.
+
+    ```alert
+    Font Awesome uses the [Font Awesome Free License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt).
+    ```
+
+    [01]: https://fontawesome.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - fa
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 5.15.1
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 4
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - regular
+      - solid
+      - brands
+    default: regular
+  variants:
+    title: Library Variants Map
+    description: Maps a friendly variant name to the icon's prefix.
+    schematize:
+      weight: 5
+      details: |
+        Use this option to create a map of friendly names for icon variants to generate their final icon
+        name to retrieve from the library.
+    type: object
+    properties:
+      regular:
+        title: Regular Variant
+        description: Maps the variant name `regular` for Font Awesome.
+        type: string
+        default: far
+      solid:
+        title: Solid Variant
+        description: Maps the variant name `solid` for Font Awesome.
+        type: string
+        default: fas
+      brands:
+        title: Brands Variant
+        description: Maps the variant name `brands` for Font Awesome.
+        type: string
+        default: fab
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: font_awesome.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/heroicons.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/heroicons.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: heroicons.schema.yaml
+title: Heroicons
+description: Settings for the Heroicons library.
+schematize:
+  weight: 4
+  details: |
+    These options control the registration of the [Heroicons][01] library.
+
+    ```alert
+    Heroicons uses the [MIT License](https://github.com/tailwindlabs/heroicons/blob/master/LICENSE).
+    ```
+
+    [01]: https://heroicons.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - hero
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 2.0.1
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 4
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - outline
+      - solid
+      - mini
+    default: outline
+  variants:
+    title: Library Variants Map
+    description: Maps a friendly variant name to the icon's prefix.
+    schematize:
+      weight: 5
+      details: |
+        Use this option to create a map of friendly names for icon variants to generate their final icon
+        name to retrieve from the library.
+    type: object
+    properties:
+      outline:
+        title: Outline Variant
+        description: Maps the variant name `outline` for Heroicons.
+        type: string
+        default: 24/outline
+      solid:
+        title: Solid Variant
+        description: Maps the variant name `solid` for Heroicons.
+        type: string
+        default: 24/solid
+      mini:
+        title: Brands Variant
+        description: Maps the variant name `mini` for Heroicons.
+        type: string
+        default: 20/solid
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: heroicons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/iconoir.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/iconoir.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: iconoir.schema.yaml
+title: Iconoir
+description: Settings for the Iconoir library.
+schematize:
+  weight: 5
+  details: |
+    These options control the registration of the [Iconoir][01] library.
+
+    ```alert
+    Iconoir uses the [MIT License](https://github.com/lucaburgio/iconoir/blob/master/LICENSE).
+    ```
+
+    [01]: https://iconoir.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default: []
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN.You can always use a specific released version of the
+        library if you prefer.
+    type: string
+    default: latest
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: iconoir.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/ionicons.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/ionicons.yaml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: ionicons.schema.yaml
+title: Ionicons
+description: Settings for the Ionicons library.
+schematize:
+  weight: 6
+  details: |
+    These options control the registration of the [Ionicons][01] library.
+
+    ```alert
+    Ionicons uses the [MIT License](https://github.com/ionic-team/ionicons/blob/master/LICENSE).
+    ```
+
+    [01]: https://ionicons.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - ion
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 5.1.2
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 4
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - outline
+      - filled
+      - sharp
+    default: outline
+  variants:
+    title: Library Variants Map
+    description: Maps a friendly variant name to the icon's prefix.
+    schematize:
+      weight: 5
+      details: |
+        Use this option to create a map of friendly names for icon variants to generate their final icon
+        name to retrieve from the library.
+    type: object
+    properties:
+      outline:
+        title: Outline Variant
+        description: Maps the variant name `outline` for Ionicons.
+        type: string
+        default: ''
+      filled:
+        title: Filled Variant
+        description: Maps the variant name `filled` for Ionicons.
+        type: string
+        default: -filled
+      sharp:
+        title: Sharp Variant
+        description: Maps the variant name `sharp` for Ionicons.
+        type: string
+        default: -sharp
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: ionicons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/jam_icons.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/jam_icons.yaml
@@ -1,0 +1,93 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: jam_icons.schema.yaml
+title: Jam Icons
+description: Settings for the Jam Icons library.
+schematize:
+  weight: 7
+  details: |
+    These options control the registration of the [Jam Icons][01] library.
+
+    ```alert
+    Jam Icons uses the [MIT License](https://github.com/michaelampr/jam/blob/master/LICENSE).
+    ```
+
+    [01]: https://jam-icons.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - jam
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 2.0.0
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 4
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - regular
+      - filled
+    default: regular
+  variants:
+    title: Library Variants Map
+    description: Maps a friendly variant name to the icon's prefix.
+    schematize:
+      weight: 5
+      details: |
+        Use this option to create a map of friendly names for icon variants to generate their final icon
+        name to retrieve from the library.
+    type: object
+    properties:
+      regular:
+        title: Regular Variant
+        description: Maps the variant name `regular` for Ionicons.
+        type: string
+        default: ''
+      filled:
+        title: Filled Variant
+        description: Maps the variant name `filled` for Ionicons.
+        type: string
+        default: -f
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: jam_icons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/lucide.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/lucide.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: lucide.schema.yaml
+title: Lucide
+description: Settings for the Lucide icon library.
+schematize:
+  weight: 8
+  details: |
+    These options control the registration of the [Lucide][01] library.
+
+    ```alert
+    Lucide uses the [MIT License](https://github.com/lucide-icons/lucide/blob/master/LICENSE).
+    ```
+
+    [01]: https://lucide.dev/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default: []
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. You can always use a specific released version of the
+        library if you prefer.
+    type: string
+    default: latest
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: lucide.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/material_icons.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/material_icons.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: material_icons.schema.yaml
+title: Material Icons
+description: Settings for the Material Icons icon library.
+schematize:
+  weight: 9
+  details: |
+    These options control the registration of the [Material Icons][01] library.
+
+    ```alert
+    Material Icons uses the [Apache 2.0 License](https://github.com/google/material-design-icons/blob/master/LICENSE).
+    ```
+
+    [01]: https://material.io/resources/icons/?style=baseline
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - material
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 1.0.5
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 4
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - outline
+      - round
+      - sharp
+    default: outline
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: material_icons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/remix_icon.yml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/remix_icon.yml
@@ -1,0 +1,99 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: remix_icon.schema.yaml
+title: Remix Icon
+description: Settings for the Remix Icon library.
+schematize:
+  weight: 10
+  details: |
+    These options control the registration of the [Remix Icon][01] library.
+
+    ```alert
+    Remix Icon uses the [Apache 2.0 License](https://github.com/Remix-Design/RemixIcon/blob/master/License).
+    ```
+
+    [01]: https://remixicon.com/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - remix
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 2.5.0
+  default_category:
+    title: Default Icon Category
+    schematize:
+      weight: 4
+      details: |
+        Defines the default category to use for the icon library.
+    type: string
+    enum:
+      - buildings
+      - business
+      - communication
+      - design
+      - development
+      - device
+      - document
+      - editor
+      - finance
+      - health
+      - logos
+      - map
+      - media
+      - others
+      - system
+      - user
+      - weather
+    default: system
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 5
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - line
+      - fill
+    default: line
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: ionicons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/tabler_icons.yml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/tabler_icons.yml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: tabler_icons.schema.yaml
+title: Tabler Icons
+description: Settings for the Tabler Icons library.
+schematize:
+  weight: 11
+  details: |
+    These options control the registration of the [Tabler Icons][01] library.
+
+    ```alert
+    Tabler Icons uses the [MIT License](https://github.com/tabler/tabler-icons/blob/master/LICENSE).
+    ```
+
+    [01]: https://tabler-icons.io/
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - tabler
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 1.68.0
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: tabler_icons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/unicons.yml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/icon_libraries/unicons.yml
@@ -1,0 +1,95 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: unicons.schema.yaml
+title: Unicons
+description: Settings for the Unicons icon library.
+schematize:
+  weight: 12
+  details: |
+    These options control the registration of the [Unicons][01] library.
+
+    ```alert
+    Unicons uses the [Apache 2.0 License](https://github.com/Iconscout/unicons/blob/master/LICENSE).
+
+    Icons that require a specific license aren't included in the default registration.
+    ```
+
+    [01]: https://iconscout.com/unicons
+type: object
+properties:
+  enabled:
+    title: Enable Library
+    description: Choose whether to enable the icon library
+    schematize:
+      weight: 1
+      details: |
+        Use this setting to choose whether the icon library is available.
+    type: boolean
+    default: true
+  aliases:
+    title: Library Aliases
+    description: Define any number of aliases for the icon library.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to specify alternate short names for the library. You can use these names instead
+        of the full library name when specifying the library in your markup or other settings.
+    type: array
+    items:
+      type: string
+    default:
+      - ion
+  version:
+    title: Library Version
+    description: Choose the version of the library to load.
+    schematize:
+      weight: 3
+      details: |
+        Choose the version of the library to load from the CDN. Platen regularly updates this version after
+        testing. You can always use a specific released version of the library if you prefer.
+    type: string
+    default: 3.0.3
+  default_variant:
+    title: Library Default Variant
+    description: Choose the default icon variant to use for the library.
+    schematize:
+      weight: 4
+      details: |
+        Use this option to set the default variant for icons from this library.
+    type: string
+    enum:
+      - line
+      - solid
+    default: line
+  variants:
+    title: Library Variants Map
+    description: Maps a friendly variant name to the icon's prefix.
+    schematize:
+      weight: 5
+      details: |
+        Use this option to create a map of friendly names for icon variants to generate their final icon
+        name to retrieve from the library.
+    type: object
+    properties:
+      line:
+        title: Line Variant
+        description: Maps the variant name `line` for Unicons.
+        type: string
+        default: ''
+      solid:
+        title: Solid Variant
+        description: Maps the variant name `solid` for Unicons.
+        type: string
+        default: s
+  registration:
+    title: Registration Options
+    description: Settings for how the library is registered.
+    schematize:
+      weight: 99
+    type: object
+    properties:
+      script:
+        title: Registration Script
+        description: Specify the name of the registration script.
+        type: string
+        default: unicons.js

--- a/modules/platen/_schema_data/schemas/platen/site/features/shoelace/options.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/features/shoelace/options.yaml
@@ -1,0 +1,184 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: options.schema.yaml
+title: Shoelace Feature Options
+description: Settings that control the site's integration with Shoelace.
+schematize:
+  details: |
+    Platen is in the process of more closely integrating the excellent set of web components from [Shoelace][01] into
+    the site theme. This gives you a set of very configurable and customizable components to use on your site and in
+    your markup.
+
+    [01]: https://shoelace.style
+type: object
+properties:
+  enabled:
+    title: Enable Shoelace
+    description: Choose whether Platen integrates with Shoelace.
+    schematize:
+      weight: 1
+      details: |
+        Choose whether the site can use Shoelace web components. The default is `true`.
+
+        If you disable the Shoelace web components, you may need to radically update the markup and layout for Platen.
+    type: boolean
+    default: true
+  always_load:
+    title: Always Load Shoelace
+    description: Choose whether the link to the Shoelace library is always added to every page.
+    schematize:
+      weight: 2
+      details: |
+        Use this setting to choose whether the link to the Shoelace library should be added to every page. Platen uses
+        Shoelace's autoloading feature, which means that it only retrieves code from Shoelace on an as-needed basis.
+
+        We strongly recommend leaving this option set to `true` to minimize complexity. This allows you to use any
+        Shoelace components in your own markdown or special markup without needing to add handlers to cherry pick the
+        components yourself.
+    type: boolean
+    default: true
+  version:
+    title: Shoelace Version
+    description: Choose the version of Shoelace to load.
+    schematize:
+      weight: 3
+      details: |
+        Use this setting to choose the version of Shoelace to load for your site. Platen regularly updates this version
+        after testing. You can override it to specify an earlier version or set this value to `latest` to always
+        retrieve the latest released version.
+    type: string
+    default: 2.4.0
+  icons:
+    title: Shoelace Icon Options
+    description: Settings for Shoelace's icons.
+    schematize:
+      weight: 4
+      details: |
+        Platen supports automatic registration and easier use of icons through Shoelace. It has built-in support for a
+        dozen different icon libraries.
+    type: object
+    properties:
+      default_library:
+        title: Default Icon Library
+        description: Sets the default icon library for your site.
+        schematize:
+          weight: 1
+          details: |
+            You can use this setting to use a different icon library by default. As long as this setting maps to the
+            name or alias of a registered library, Platen will use that library by default for its markup and any icons
+            you specify for theme components.
+        default: builtin_bootstrap
+        oneOf:
+          - type: string
+            enum:
+              - builtin_bootstrap
+              - boxicons
+              - font_awesome
+              - heroicons
+              - iconoir
+              - ionicons
+              - jam_icons
+              - lucide
+              - material_icons
+              - remix_icon
+              - tabler_icons
+              - unicons
+          - type: string
+      always_load_libraries:
+        title: Always Load Libraries List
+        description: Define any number of libraries to always register and load for a page.
+        schematize:
+          weight: 2
+          details: |
+            Use this setting to create a list of icon libraries that Platen should always load, even when the icons
+            aren't used in Platen's markup or a theme component. This is mostly useful if you're using inline Shoelace
+            components or adding your own markup outside of Platen's configuration.
+
+            By default, Platen checks any specified icon in your markup or theme components and maintains a list of
+            icon libraries to register for each page on your behalf. You can freely use the configured libraries without
+            having to ensure they register.
+        type: array
+        default: []
+        items:
+          oneOf:
+            - type: string
+              enum:
+                - builtin_bootstrap
+                - boxicons
+                - font_awesome
+                - heroicons
+                - iconoir
+                - ionicons
+                - jam_icons
+                - lucide
+                - material_icons
+                - remix_icon
+                - tabler_icons
+                - unicons
+            - type: string
+      libraries:
+        title: Icon Library Settings
+        description: Controls the settings for various known icon libraries.
+        schematize:
+          weight: 3
+          details: |
+            These settings control the registration and behavior for icon libraries to use in Shoelace web components
+            for Platen. Platen provides default configuration and registration for a dozen different icon libraries.
+
+            You can also define your own icon libraries to register with Platen. For now, see the implementations for
+            the existing libraries. You can reach out to the maintainers if you have questions or want another library
+            added to the built-in supported libraries.
+        type: object
+        properties:
+          builtin_bootstrap:
+            $ref: ./icon_libraries/default.yaml
+          boxicons:
+            $ref: ./icon_libraries/boxicons.yaml
+          font_awesome:
+            $ref: ./icon_libraries/font_awesome.yaml
+          heroicons:
+            $ref: ./icon_libraries/heroicons.yaml
+          iconoir:
+            $ref: ./icon_libraries/iconoir.yaml
+          ionicons:
+            $ref: ./icon_libraries/ionicons.yaml
+          jam_icons:
+            $ref: ./icon_libraries/jam_icons.yaml
+          lucide:
+            $ref: ./icon_libraries/lucide.yaml
+          material_icons:
+            $ref: ./icon_libraries/material_icons.yaml
+          remix_icon:
+            $ref: ./icon_libraries/remix_icon.yaml
+          tabler_icons:
+            $ref: ./icon_libraries/tabler_icons.yaml
+          unicons:
+            $ref: ./icon_libraries/unicons.yaml
+  partials:
+    title: Feature Partials
+    description: Define a map of partials for Platen to inject as needed.
+    schematize:
+      details: |
+        Define a map of partials for Platen to inject as needed. These partials are only
+        injected when [sref:`enabled`] is set to `true`.
+
+        <!-- Reference Links -->
+        [sref:`enabled`]: platen.site.features.pwa.enabled
+      weight: 99
+      skip_schema_render: true
+    type: object
+    properties:
+      header:
+        title: Header Partial
+        description: Injects a partial into the HTML header.
+        schematize:
+          details: |
+            If specified, this partial is processed in the HTML header with the current page's context. The default
+            value is `platen/features/shoelace/header`. You can overwrite this value, replacing it with another partial
+            entirely, or you can add the same file to your own theme or site, effectively replacing it.
+
+            The default partial loads Shoelace from the CDN for use. It also adds a helper script, called `modeSwap.js`
+            from `assets/scripts/shoelace/modeSwap.js`, which helps support automatic theming between light and dark
+            modes. Finally, it sets up registration for Shoelace's icon libraries.
+        type: string
+        default: platen/features/shoelace/header

--- a/modules/platen/_schema_data/schemas/platen/site/markup/alerts.yaml
+++ b/modules/platen/_schema_data/schemas/platen/site/markup/alerts.yaml
@@ -185,7 +185,7 @@ properties:
             [05]: sl.component:icon?id=default-icons
           weight: 1
         type: string
-        default: exclamation-octagon
+        default: exclamation-octagon@builtin_bootstrap
       default:
         title: Default 'default' Alert Variant Icon
         description: Specify the name of the default icon for default variant alerts.
@@ -208,7 +208,7 @@ properties:
             [05]: sl.component:icon?id=default-icons
           weight: 2
         type: string
-        default: gear
+        default: gear@builtin_bootstrap
       primary:
         title: Default 'primary' Alert Variant Icon
         description: Specify the name of the default icon for primary variant alerts.
@@ -231,7 +231,7 @@ properties:
             [05]: sl.component:icon?id=default-icons
           weight: 3
         type: string
-        default: info-circle
+        default: info-circle@builtin_bootstrap
       success:
         title: Default 'success' Alert Variant Icon
         description: Specify the name of the default icon for success variant alerts.
@@ -254,7 +254,7 @@ properties:
             [05]: sl.component:icon?id=default-icons
           weight: 4
         type: string
-        default: check2-circle
+        default: check2-circle@builtin_bootstrap
       warning:
         title: Default 'warning' Alert Variant Icon
         description: Specify the name of the default icon for warning variant alerts.
@@ -277,7 +277,7 @@ properties:
             [05]: sl.component:icon?id=default-icons
           weight: 5
         type: string
-        default: exclamation-triangle
+        default: exclamation-triangle@builtin_bootstrap
   use_default_icons:
     title: Use Default Icons
     description: Set whether rendered alerts use configured icons by default

--- a/modules/platen/assets/scripts/platen/module.js
+++ b/modules/platen/assets/scripts/platen/module.js
@@ -49,6 +49,39 @@ export function toggleTableOfContents() {
   }
 }
 
+/**
+ * The `stopPropagationInTree` function is used to keep intentional interactive events in a
+ * Shoelace tree-item from bubbling up and causing the parent tree item to collapse or expand.
+ * 
+ * This is particularly useful for trees that include several interactive objects, like the trees
+ * for the Table of Contents links.
+ * 
+ * This function must be called once against each tree you want to prevent propagation in. Every
+ * found element matching the targetSelector in that tree is set to stop the event propagation for
+ * events with the specified type.
+ * 
+ * To stop propagation for multiple events or trees, call the function for each event and tree.
+ * 
+ * @param {string} targetSelector The CSS selector string for the interactive object to target.
+ * @param {string} treeSelector The CSS selector string for the Shoelace tree the target is in.
+ * @param {string} eventType  The type of event to stop propagation for.
+ */
+export async function stopPropagationInTree(targetSelector, treeSelector = 'sl-tree', eventType = 'click') {
+  customElements.whenDefined('sl-tree').then(async () => {
+    const tree = document.querySelector(treeSelector)
+
+    if (tree != undefined) await tree.updateComplete;
+
+    document.querySelectorAll(targetSelector).forEach(element => {
+      element.addEventListener(
+        eventType,
+        event => { event.stopPropagation() },
+        true
+      )
+    })
+  })
+}
+
 export const Version = '0.1.0'
 
 export default Version

--- a/modules/platen/assets/scripts/platen/module.js
+++ b/modules/platen/assets/scripts/platen/module.js
@@ -20,6 +20,35 @@ export function onFirstVisible(element, callback) {
   }).observe(element);
 }
 
-const Version = '0.1.0'
+const SiteMenuControlID = 'menu-control'
+const TableOfContentsControlID = 'toc-control'
+
+export function getSiteMenuControl() {
+  return document.getElementById(SiteMenuControlID)
+}
+
+export function getTableOfContentsControl() {
+  return document.getElementById(TableOfContentsControlID)
+}
+
+export function showSiteMenu() {
+  console.log('showing site menu')
+  getSiteMenuControl().checked = true
+}
+
+export function hideSiteMenu() {
+  getSiteMenuControl().checked = false
+}
+
+export function toggleTableOfContents() {
+  let toc = getTableOfContentsControl()
+  if (toc.checked != true) {
+    toc.checked = true
+  } else {
+    toc.checked = false
+  }
+}
+
+export const Version = '0.1.0'
 
 export default Version

--- a/modules/platen/assets/styles/markup/_details.scss
+++ b/modules/platen/assets/styles/markup/_details.scss
@@ -1,9 +1,4 @@
 .markdown sl-details.platen-details {
-  // When custom icons are used, don't rotate.
-  &.no-rotate-icon::part(summary-icon) {
-    rotate: none;
-  }
-
   // Ensure the summary element doesn't have vertical margins to keep the
   // height standard.
   [slot="summary"] > * {

--- a/modules/platen/assets/styles/mobile/_menu.scss
+++ b/modules/platen/assets/styles/mobile/_menu.scss
@@ -10,6 +10,15 @@
     z-index: 1;
   }
 
+  label[for="menu-control"] {
+    &:has(sl-icon-button) {
+      font-size: 1.5em;
+    }
+    sl-icon-button::part(base) {
+      color: var(--body-font-color)
+    }
+  }
+
   #menu-control:focus ~ main label[for="menu-control"] {
     @include outline;
   }

--- a/modules/platen/assets/styles/mobile/_table_of_contents.scss
+++ b/modules/platen/assets/styles/mobile/_table_of_contents.scss
@@ -7,6 +7,15 @@
     display: none;
   }
 
+  label[for="toc-control"] {
+    &:has(sl-icon-button) {
+      font-size: 1.5em;
+    }
+    sl-icon-button::part(base) {
+      color: var(--body-font-color)
+    }
+  }
+
   #toc-control:focus ~ main label[for="toc-control"] {
     @include outline;
   }

--- a/modules/platen/assets/styles/platen.scss
+++ b/modules/platen/assets/styles/platen.scss
@@ -102,6 +102,9 @@
 // because they may/will use these utils.
 {{ partial $importPartial (dict "StylesMap" $theme.styles.utils "RootFolder" "utils") }}
 
+// The basic global classes for shoelace components
+{{ partial $importPartial (dict "StylesMap" $theme.styles.shoelace "RootFolder" "shoelace") }}
+
 // The base styles for general structure on the site.
 {{ partial $importPartial (dict "StylesMap" $theme.styles.base "RootFolder" "base") }}
 

--- a/modules/platen/assets/styles/platen/_table_of_contents.scss
+++ b/modules/platen/assets/styles/platen/_table_of_contents.scss
@@ -18,3 +18,43 @@
     margin-top: 0;
   }
 }
+
+nav#TableOfContents, nav#TableOfContentsMobile {
+  sl-tree-item {
+    // Override the font size for the tree items for the ToC
+    &::part(label), &::part(expand-button) {
+      font-size: $font-size-small;
+      line-height: unset;
+    }
+    &::part(expand-button) {
+      height: 1em;
+    }
+
+    /*
+      Ensure non-expandable entries have their links take up the full width of
+      the line; that way, clicking anywhere on the line takes you to the
+      heading. Don't do it for entries with children, so clicking the line
+      still expands/collapses the entry rather than jumping to it.
+    */
+    &:not(:has([slot="children"]))::part(label) {
+      flex-grow: 1;
+    }
+
+    // Ensure the link always fills the available space
+    a {
+      width: 100%;
+    }
+
+    // Ignore the default selection highlighting for the TOC
+    &::part(item--selected) {
+      background-color: var(--body-background);
+    }
+
+    // Disable the border for items in the TOC
+    &::part(item), &::part(item--expanded), &::part(item--selected) {
+      border-inline-start-color: unset;
+      border-inline-start-style: unset;
+      border-inline-start-width: unset;
+    }
+  }
+}

--- a/modules/platen/assets/styles/shoelace/icons.scss
+++ b/modules/platen/assets/styles/shoelace/icons.scss
@@ -1,0 +1,30 @@
+sl-tree {
+  &.no-rotate-icon sl-tree-item::part(expand-button) {
+    /*
+        Disable the expand/collapse rotation animation when using custom icons;
+        only the default caret should rotate.
+    */
+    rotate: none;
+  }
+
+  sl-tree-item {
+    /*
+      Disable the expand/collapse rotation animation when the tree item doesn't
+      have any children; the rotation animation causes a strange box to bubble
+      up where the icon would be.
+    */
+    &:not(:has([slot="children"]))::part(expand-button) {
+      rotate: none;
+    }
+  }
+}
+
+sl-details {
+  &.no-rotate-icon::part(summary-icon) {
+    /*
+        Disable the expand/collapse rotation animation when using custom icons;
+        only the default caret should rotate.
+    */
+    rotate: none;
+  }
+}

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -160,7 +160,11 @@ platen:
     date_format: "January 2, 2006"             # BookDateFormat
     header:
       title_as_heading: false
-    menu_root_section: /                        # BookSection
+    menu:
+      root_section:   /                        # BookSection
+      languages_icon:
+          use_legacy: false
+          name:       translate
     footer:
       last_edited_on: # button
         enabled: true

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -175,18 +175,18 @@ platen:
     menu:
       root_section:   /                        # BookSection
       languages_icon:
-          name:           translate
+          name:           translate@builtin_bootstrap
           use_legacy:     true
     mobile:
       menu_control:
-        name:  list
+        name:  list@builtin_bootstrap
         label: i18n!menu_control
         tooltip:
           placement: right
         use_legacy: true
       toc_control:
         use_legacy: true
-        name: list-columns
+        name: list-columns@builtin_bootstrap
         label: i18n!toc_control
         tooltip:
           placement: left
@@ -194,14 +194,14 @@ platen:
       last_edited_on: # button
         enabled: true
         prefix_icon:
-          name: calendar-fill
+          name: calendar-fill@builtin_bootstrap
         variant: text
         show_elapsed: true
         use_legacy: true
       edit_this_page: #button
         enabled: true
         prefix_icon:
-          name: pencil-fill
+          name: pencil-fill@builtin_bootstrap
         variant: text
         use_legacy: true
   features:

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -88,6 +88,9 @@ platen:
           enabled: true
         responsiveness:
           enabled: true
+      shoelace:
+        icons:
+          enabled: true
       mobile:
         header:
           enabled: true
@@ -165,7 +168,7 @@ platen:
       #   guide_width: 3px
       # collapse_icon: dash-square
       # expand_icon:   plus-square
-      use_legacy: true
+      use_legacy: false
     date_format: "January 2, 2006"             # BookDateFormat
     header:
       title_as_heading: false
@@ -174,6 +177,19 @@ platen:
       languages_icon:
           use_legacy: false
           name:       translate
+    mobile:
+      menu_control:
+        use_legacy: true
+        name: list
+        label: i18n!menu_control
+        tooltip:
+          placement: right
+      toc_control:
+        use_legacy: true
+        name: list-columns
+        label: i18n!toc_control
+        tooltip:
+          placement: left
     footer:
       last_edited_on: # button
         enabled: true
@@ -207,8 +223,8 @@ platen:
         header: platen/features/alpine/header
     shoelace:
       enabled:     true
-      always_load: false
-      version:     2.3.0
+      always_load: true
+      version:     2.4.0
       icons:
         default_library: builtin_bootstrap
         always_load_libraries: []
@@ -352,11 +368,11 @@ platen:
       classes: []
       variant: primary
       icons:
-        danger:  exclamation-octagon
-        default: gear
-        primary: info-circle
-        success: check2-circle
-        warning: exclamation-triangle
+        danger:  exclamation-octagon@builtin_bootstrap
+        default: gear@builtin_bootstrap
+        primary: info-circle@builtin_bootstrap
+        success: check2-circle@builtin_bootstrap
+        warning: exclamation-triangle@builtin_bootstrap
       use_default_icons: true
       partials:
         renderers:

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -168,22 +168,22 @@ platen:
       #   guide_width: 3px
       # collapse_icon: dash-square
       # expand_icon:   plus-square
-      use_legacy: false
+      use_legacy: true
     date_format: "January 2, 2006"             # BookDateFormat
     header:
       title_as_heading: false
     menu:
       root_section:   /                        # BookSection
       languages_icon:
-          use_legacy: false
-          name:       translate
+          name:           translate
+          use_legacy:     true
     mobile:
       menu_control:
-        use_legacy: true
-        name: list
+        name:  list
         label: i18n!menu_control
         tooltip:
           placement: right
+        use_legacy: true
       toc_control:
         use_legacy: true
         name: list-columns
@@ -197,11 +197,13 @@ platen:
           name: calendar-fill
         variant: text
         show_elapsed: true
+        use_legacy: true
       edit_this_page: #button
         enabled: true
         prefix_icon:
           name: pencil-fill
         variant: text
+        use_legacy: true
   features:
     search:                                   # booksearch
       enabled: true

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -42,7 +42,7 @@ platen:
         body-background: "#343a40"
         body-font-color: "#e9ecef"
         icon-filter: brightness(0) invert(1)
-      custom_css:
+      custom_css: {}
     styles:
       base:
         html:
@@ -156,7 +156,16 @@ platen:
     table_of_contents:
       minimum_level: 2
       maximum_level: 4
-      render: true
+      render:        true
+      # indentation:
+      #   size: 1rem
+      #   guide_color: green
+      #   guide_offset: 0
+      #   guide_style: solid
+      #   guide_width: 3px
+      # collapse_icon: dash-square
+      # expand_icon:   plus-square
+      use_legacy: true
     date_format: "January 2, 2006"             # BookDateFormat
     header:
       title_as_heading: false

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -161,6 +161,18 @@ platen:
     header:
       title_as_heading: false
     menu_root_section: /                        # BookSection
+    footer:
+      last_edited_on: # button
+        enabled: true
+        prefix_icon:
+          name: calendar-fill
+        variant: text
+        show_elapsed: true
+      edit_this_page: #button
+        enabled: true
+        prefix_icon:
+          name: pencil-fill
+        variant: text
   features:
     search:                                   # booksearch
       enabled: true

--- a/modules/platen/i18n/en.yaml
+++ b/modules/platen/i18n/en.yaml
@@ -7,6 +7,12 @@
 - id: Last modified by
   translation: Last modified by
 
+- id: menu_control
+  translation: Show site menu
+
+- id: toc_control
+  translation: Toggle the table of contents
+
 - id: Expand
   translation: Expand
 

--- a/modules/platen/layouts/_default/baseof.html
+++ b/modules/platen/layouts/_default/baseof.html
@@ -18,7 +18,9 @@
 </head>
 <body {{ $bodyAttributes | safeHTMLAttr }}>
   <input type="checkbox" class="hidden toggle" id="menu-control" />
-  <input type="checkbox" class="hidden toggle" id="toc-control" />
+  {{ if (partialCached "platen/utils/shouldRenderToC" page page) -}}
+    <input type="checkbox" class="hidden toggle" id="toc-control" />
+  {{- end }}
   <main class="container flex">
     <aside class="platen-menu">
       <div class="platen-menu-content">

--- a/modules/platen/layouts/_default/baseof.html
+++ b/modules/platen/layouts/_default/baseof.html
@@ -1,29 +1,15 @@
-{{/*
-  Determine if the ToC should be rendered:
-
-  - If set in the page params, use that value.
-  - If set in the site params but not the page, use that value.
-  - If not set at all, default to true.
-*/}}
-{{- $RenderToC := partial "platen/param/resolve" (
-  dict "Config"  "platen.display.table_of_contents.render"
-       "Param"   "platen.table_of_contents.render"
-       "Context" page
-       "Default" true
-) -}}
-
-{{- partial "platen/param/classes/canonicalize" -}}
 {{- $LanguageDirection := site.Language.LanguageDirection | default "ltr" -}}
 {{- $LanguageCode      := site.LanguageCode | default site.Language.Lang  -}}
 {{- $bodyAttributes    := printf `dir="%s"` $LanguageDirection            -}}
-{{- with (page.Store.Get "PlatenBodyClassAttribute") -}}
-  {{- $bodyAttributes = printf "%s %s" $bodyAttributes . -}}
+
+{{- partial "platen/param/classes/canonicalize" -}}
+{{- with $ClassAttribute := page.Store.Get "PlatenBodyClassAttribute" -}}
+  {{- $bodyAttributes = printf "%s %s" $bodyAttributes $ClassAttribute -}}
 {{- end -}}
 
 {{/* Write the HTML */}}
 <!DOCTYPE html>
-<html lang="{{ $LanguageCode }}"
-      dir="{{ $LanguageDirection }}">
+<html lang="{{ $LanguageCode }}" dir="{{ $LanguageDirection }}">
 <head>
   {{ partial "platen/htmlHead"    }}
   {{ partial "platen/inject/head" }}
@@ -56,10 +42,11 @@
 
       <label for="menu-control" class="hidden platen-menu-overlay"></label>
     </div>
-    {{ if $RenderToC }}
+    
+    {{- if (partialCached "platen/utils/shouldRenderToC" page page) }}
     <aside class="platen-toc">
       <div class="platen-toc-content">
-        {{ template "toc" }} <!-- Table of Contents -->
+        {{ template "toc" (dict "ForMobile" false) }} <!-- Table of Contents -->
       </div>
     </aside>
     {{ end }}
@@ -74,17 +61,11 @@
 {{ end }}
 
 {{ define "header" }}
-  {{- $RenderToC := partial "platen/param/resolve" (
-        dict "Config"  "platen.display.table_of_contents.render"
-             "Param"   "platen.table_of_contents.render"
-             "Context" page
-             "Default" true
-      )
-  -}}
   {{ partial "platen/header" }}
-  {{ if $RenderToC }}
+
+  {{- if (partialCached "platen/utils/shouldRenderToC" page page) }}
   <aside class="hidden clearfix">
-    {{ template "toc" }}
+    {{ template "toc" (dict "ForMobile" true) }}
   </aside>
   {{ end }}
 {{ end }}
@@ -115,5 +96,5 @@
 {{ end }}
 
 {{ define "toc" }}
-  {{ partial "platen/toc" }}
+  {{ partial "platen/toc" . }}
 {{ end }}

--- a/modules/platen/layouts/_default/baseof.html
+++ b/modules/platen/layouts/_default/baseof.html
@@ -1,3 +1,5 @@
+{{- partialCached "platen/param/validate/legacy" "Cache" "Cache" -}}
+
 {{- $LanguageDirection := site.Language.LanguageDirection | default "ltr" -}}
 {{- $LanguageCode      := site.LanguageCode | default site.Language.Lang  -}}
 {{- $bodyAttributes    := printf `dir="%s"` $LanguageDirection            -}}

--- a/modules/platen/layouts/partials/platen/features/shoelace/templates/button.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/templates/button.html
@@ -1,0 +1,39 @@
+{{/*
+    Shoelace Template: button
+
+    Renders an <sl-button> element on a page.
+
+    This template partial expects a dict with the following keys:
+
+    - Attributes: (Optional) The canonicalized string of the button's attributes.
+    - Label: (Mandatory) The raw text or HTML to render as the button's
+      displayed content.
+    - PrefixIcon: (Optional) A string representing the name of the icon or a
+      dictionary of options for the icon to display before the button's label.
+    - SuffixIcon: (Optional) A string representing the name of the icon or a
+      dictionary of options for the icon to display after the button's label.
+
+    This template partial renders an sl-button element with its label and
+    optional prefix/suffix icons. The icon rendering is managed by the icon
+    template.
+
+    All canonicalizing for the button's attributes and label should be handled
+    by the caller, but the icon template can handle canonicalizing the icons
+    as needed.
+*/}}
+{{/*  Define partials for easier renaming/use  */}}
+{{- $IconTemplate := "platen/features/shoelace/templates/icon" -}}
+{{/*  Handle parameters  */}}
+{{- $Params     := .                                 -}}
+{{- $Attributes := $Params.Attributes | safeHTMLAttr -}}
+{{- $Label      := $Params.Label      | safeHTML     -}}
+{{- $PrefixIcon := $Params.PrefixIcon | default ""   -}}
+{{- $SuffixIcon := $Params.SuffixIcon | default ""   -}}
+
+<sl-button {{ $Attributes }}>
+  {{- partial $IconTemplate (dict "Icon" $PrefixIcon "Slot" "prefix") -}}
+  {{ $Label }}
+  {{- partial $IconTemplate (dict "Icon" $SuffixIcon "Slot" "suffix") -}}
+</sl-button>
+
+{{- $_ := "this exists only to trim the trailing whitespace" -}}

--- a/modules/platen/layouts/partials/platen/features/shoelace/templates/icon.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/templates/icon.html
@@ -1,0 +1,61 @@
+{{/*
+    Shoelace Template: icon
+
+    Renders an <sl-icon> element on a page.
+
+    This template partial expects a dict with the following keys:
+
+    - Icon: (Mandatory) Either a string representing the name of the icon to
+      render or the options dictionary for the icon.
+    - Slot: (Optional) The slot for the icon. Useful when adding the icon to
+      another element where the slot is fixed by the caller and not the icon's
+      definition.
+
+    Params.Icon is always used to resolve the icon into a canonicalized
+    dictionary of options. If the value is a string, the return is a dictionary
+    that includes the icon's canonicalized name and library. If the value is
+    a dictionary, the return is that dictionary with the name and library keys
+    updated to their canonical value.
+
+    If Params.Slot is defined, it is merged into the canonicalized icon options
+    dictionary.
+
+    The partial then creates the attribute list for the icon from the options,
+    inserting them to the element and rendering it if the option dictionary
+    isn't empty.
+
+    If the dictionary is empty, nothing is rendered.
+*/}}
+{{/*  Define partials for easier renaming/use  */}}
+{{- $getSafeAttributes  := "platen/utils/getSafeAttributes"                    -}}
+{{- $resolveIconOptions := "platen/features/shoelace/utils/resolveIconOptions" -}}
+{{/*  Handle parameters  */}}
+{{- $Params := .            -}}
+{{- $Icon   := $Params.Icon -}}
+{{- $Slot   := $Params.Slot -}}
+
+{{- with $Params.Icon -}}
+  {{/*  Resolve the icon options from the parameters.  */}}
+  {{- $attributeMap := partialCached $resolveIconOptions $Params $Params.Icon -}}
+  {{- $attributes   := slice                                                  -}}
+
+  {{- with $attributeMap -}}
+    {{- with $Slot -}}
+      {{- $attributeMap = merge $attributeMap (dict "slot" $Slot) -}}
+    {{- end -}}
+
+    {{- range $Key, $Value := $attributeMap -}}
+      {{- if ne "variant" $Key -}}
+        {{- $Attribute := printf `%s="%s"` $Key (print $Value) -}}
+        {{- $attributes = $attributes | append $Attribute      -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $attributeParams := dict "Attributes" $attributes "IndentCount" 9 -}}
+  {{- $IconAttributes  := partial $getSafeAttributes $attributeParams   -}}
+
+  {{- with $IconAttributes -}}
+    <sl-icon {{ $IconAttributes }}></sl-icon>
+  {{- end -}}
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/features/shoelace/templates/iconButton.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/templates/iconButton.html
@@ -1,0 +1,114 @@
+{{/*
+    Shoelace Template: iconButton
+
+    Renders an <sl-icon-button> element on a page inside an <sl-tooltip>.
+
+    This template partial expects a dict with the following keys:
+
+    - Button: (Mandatory) A dictionary of options for the icon button.
+    - Tooltip: (Optional) A dictionary of options for the tooltip.
+    - Label: (Optional) A string to use as the accessible label for the button.
+
+    If Params.Button.label is defined, the partial uses that value for the icon
+    button's accessible label. Params.Label should be used as a fallback value
+    for when Params.Button.label isn't defined.
+
+    If Params.Label or Params.Button.label has the prefix `i18n!`, the text
+    after that prefix is used as the lookup key in the site's i18n dictionary
+    to resolve the label text. This way, you can provide multiple translations
+    for a button's label.
+
+    If Params.Tooltip.content is defined, that value is used for the tooltip's
+    display text. If it isn't, the partial defaults to Params.Button.label,
+    then Params.Label for the value.
+
+    The sl-icon-button is always rendered inside an sl-tooltip element that has
+    the `hoist` and `content` attributes set. The sl-icon-button always has the
+    `name` and `label attributes set. If the icon isn't from the builtin
+    library, the `library` attribute is also set.
+
+    All other options for the tooltip and button are passed as attributes if
+    they're not part of the known skip list for the element.
+*/}}
+{{/*  Define partials for easier renaming/use  */}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+{{/*  Define constants  */}}
+{{- $SkipButtonOptions  := slice "use_legacy" "classes" "label" "tooltip" -}}
+{{- $SkipTooltipOptions := slice "content" "classes" "hoist"              -}}
+{{- $I18nPrefix         := "i18n!"                                        -}}
+{{/*  Handle parameters  */}}
+{{- $Params         := .                                                                 -}}
+{{- $ButtonOptions  := $Params.Button  | default (dict)                                  -}}
+{{- $TooltipOptions := $Params.Tooltip | default $ButtonOptions.tooltip | default (dict) -}}
+{{- $label          := $Params.Label   | default ""                                      -}}
+{{/*  Initialize attribute slices  */}}
+{{- $tooltipAttributes := slice -}}
+{{- $buttonAttributes  := slice -}}
+
+{{/*  Canonicalize the button's attributes  */}}
+{{- with $ButtonOptions -}}
+  {{/*  Handle the button's label  */}}
+  {{- $label = $ButtonOptions.label | default $label -}}
+  {{- if hasPrefix $label $I18nPrefix -}}
+    {{- $i18n := strings.TrimPrefix $I18nPrefix $label -}}
+    {{- $label = i18n $i18n                            -}}
+  {{- end -}}
+  {{- $LabelAttribute  := printf `label="%s"` $label                 -}}
+  {{- $buttonAttributes = $buttonAttributes | append $LabelAttribute -}}
+
+  {{/*  Handle the button's classes  */}}
+  {{- $classes := slice "platen-btn" -}}
+  {{- with $ButtonOptions.classes -}}
+    {{- $classes = union $classes $ButtonOptions.classes -}}
+  {{- end -}}
+  {{- $classes          = delimit $classes " "                       -}}
+  {{- $ClassAttribute  := printf `class="%s"` $classes               -}}
+  {{- $buttonAttributes = $buttonAttributes | append $ClassAttribute -}}
+
+  {{/*  Handle remaining button attributes  */}}
+  {{- range $Name, $Value := $ButtonOptions -}}
+    {{- if not (in $SkipButtonOptions $Name) -}}
+      {{- $Attribute       := printf `%s="%s"` $Name (print $Value) -}}
+      {{- $buttonAttributes = $buttonAttributes | append $Attribute -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/*  Turn the slice into insertable attributes for the button  */}}
+  {{- $attributeParams := dict "Attributes" $buttonAttributes "IndentCount" 18 -}}
+  {{- $buttonAttributes = partial $getSafeAttributes $attributeParams          -}}
+{{- end -}}
+
+{{/*  Handle the tooltip content, falling back on the button label  */}}
+{{- $content := $TooltipOptions.content | default $label -}}
+{{- if hasPrefix $content $I18nPrefix -}}
+  {{- $i18n   := strings.TrimPrefix $I18nPrefix $content -}}
+  {{- $content = i18n $i18n                              -}}
+{{- end -}}
+{{- $ContentAttribute := printf `content="%s"` $content                -}}
+{{- $tooltipAttributes = $tooltipAttributes | append $ContentAttribute -}}
+
+{{/*  Handle any other options for tooltip, all optional  */}}
+{{- with $TooltipOptions -}}
+  {{/*  Add classes, if needed  */}}
+  {{- with $TooltipOptions.classes -}}
+    {{- $ClassAttribute   := printf `class="%s"` (delimit $TooltipOptions.classes " ") -}}
+    {{- $tooltipAttributes = $tooltipAttributes | append $ClassAttribute               -}}
+  {{- end -}}
+
+  {{/*  Handle any other specified attributes  */}}
+  {{- range $Name, $Value := $TooltipOptions -}}
+    {{- if not (in $SkipTooltipOptions $Name) -}}
+      {{- $Attribute        := printf `%s="%s"` $Name (print $Value)  -}}
+      {{- $tooltipAttributes = $tooltipAttributes | append $Attribute -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  Turn the slice into insertable attributes for the tooltip  */}}
+{{- $attributeParams  := dict "Attributes" $tooltipAttributes "IndentCount" 12 -}}
+{{- $tooltipAttributes = partial $getSafeAttributes $attributeParams           -}}
+
+<sl-tooltip {{ $tooltipAttributes }}>
+  <sl-icon-button {{ $buttonAttributes }}>
+  </sl-icon-button>
+</sl-tooltip>

--- a/modules/platen/layouts/partials/platen/features/shoelace/templates/iconButton.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/templates/iconButton.html
@@ -31,7 +31,8 @@
     they're not part of the known skip list for the element.
 */}}
 {{/*  Define partials for easier renaming/use  */}}
-{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+{{- $getSafeAttributes  := "platen/utils/getSafeAttributes"                    -}}
+{{- $resolveIconOptions := "platen/features/shoelace/utils/resolveIconOptions" -}}
 {{/*  Define constants  */}}
 {{- $SkipButtonOptions  := slice "use_legacy" "classes" "label" "tooltip" -}}
 {{- $SkipTooltipOptions := slice "content" "classes" "hoist"              -}}
@@ -47,8 +48,11 @@
 
 {{/*  Canonicalize the button's attributes  */}}
 {{- with $ButtonOptions -}}
+  {{/*  Resolve the options for name/variant/library  */}}
+  {{- $Resolving := dict "Icon" $ButtonOptions                              -}}
+  {{- $Options   := partialCached $resolveIconOptions $Resolving $Resolving -}}
   {{/*  Handle the button's label  */}}
-  {{- $label = $ButtonOptions.label | default $label -}}
+  {{- $label = $Options.label | default $label -}}
   {{- if hasPrefix $label $I18nPrefix -}}
     {{- $i18n := strings.TrimPrefix $I18nPrefix $label -}}
     {{- $label = i18n $i18n                            -}}
@@ -58,15 +62,15 @@
 
   {{/*  Handle the button's classes  */}}
   {{- $classes := slice "platen-btn" -}}
-  {{- with $ButtonOptions.classes -}}
-    {{- $classes = union $classes $ButtonOptions.classes -}}
+  {{- with $Options.classes -}}
+    {{- $classes = union $classes $Options.classes -}}
   {{- end -}}
   {{- $classes          = delimit $classes " "                       -}}
   {{- $ClassAttribute  := printf `class="%s"` $classes               -}}
   {{- $buttonAttributes = $buttonAttributes | append $ClassAttribute -}}
 
   {{/*  Handle remaining button attributes  */}}
-  {{- range $Name, $Value := $ButtonOptions -}}
+  {{- range $Name, $Value := $Options -}}
     {{- if not (in $SkipButtonOptions $Name) -}}
       {{- $Attribute       := printf `%s="%s"` $Name (print $Value) -}}
       {{- $buttonAttributes = $buttonAttributes | append $Attribute -}}

--- a/modules/platen/layouts/partials/platen/features/shoelace/templates/relativeTime.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/templates/relativeTime.html
@@ -1,0 +1,30 @@
+{{/*
+    Shoelace Template: relativeTime
+
+    This template renders an <sl-relative-time> element.
+
+    It expects input as either a string or a dictionary. If the input is a
+    string, it's used as the value of the element's `date` attribute. If the
+    input is a dictionary, the keys in the dictionary as used as attributes for
+    the element with their value set to their stringified defined value.
+*/}}
+{{- $Params := . -}}
+
+{{/*  Define partials for easier renaming/maintenance  */}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+{{/*  Initialize attribute list  */}}
+{{- $attributes := slice -}}
+
+{{- if reflect.IsMap $Params -}}
+  {{- range $Name, $Value := $Params -}}
+    {{- $Attribute := printf `%s="%s"` $Name (print $Value) -}}
+    {{- $attributes = $attributes | append $Attribute       -}}
+  {{- end -}}
+
+  {{- $SafeParams := dict "Attributes" $attributes "IndentCount" 18 -}}
+  {{- $attributes := partial $getSafeAttributes $SafeParams         -}}
+{{- else -}}
+  {{- $attributes = printf `date="%s"` $Params | safeHTMLAttr -}}
+{{- end -}}
+
+<sl-relative-time {{ $attributes }}></sl-relative-time>

--- a/modules/platen/layouts/partials/platen/features/shoelace/utils/parseIconName.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/utils/parseIconName.html
@@ -1,0 +1,94 @@
+{{/*
+    Shoelace Utility Partial: parseIconName
+
+    This partial expects to receive the name of an icon in the format:
+
+        name&variant@library
+
+    Where name is mandatory but variant and library are optional. All of these
+    are valid strings to parse:
+
+        name
+        name&variant
+        name@library
+        name&variant@library
+
+    This partial returns a dictionary with the following values:
+
+    - Name: The canonical name of the icon without the variant.
+    - Library: The canonical name of the icon's library.
+    - LibraryStatus: Whether the library is unknown, enabled, or disabled.
+    - Variant: The canonical name of the icon's variant, if any.
+    - CombinedName: The combination of name and variant, like `name&variant`
+
+    The caller can decide what to do with the returned information. Typically,
+    the caller will want to use the CombinedName and Library to render an icon.
+*/}}
+{{/*  Define partials for easier renaming/use  */}}
+{{- $getIconLibraryConfig := "platen/features/shoelace/utils/getIconLibraryConfig" -}}
+{{/*  Handle parameters  */}}
+{{- $Name := . -}} {{/* The name of the icon to parse. */}}
+{{/*  Retrieve configuration  */}}
+{{- $Key            := "platen.features.shoelace.icons"              -}}
+{{- $IconConfig     := partialCached "platen/param/getKey" $Key $Key -}}
+{{- $DefaultLibrary := $IconConfig.default_library                   -}}
+{{/*  Initialize the icon info to return  */}}
+{{- $info := dict -}}
+
+{{- with $Name -}}
+  {{/*
+      This pattern parses the input string for the icon's name, variant, and
+      library. It returns these match groups:
+
+      - 0: The entire string.
+      - 1: The name of the icon.
+      - 2: The variant of the icon, if any.
+      - 3: The library of the icon, if any.
+  */}}
+  {{- $Pattern := `^([^&@]+)(?:&([^@]+))?(?:@(.+))?$` -}}
+  {{- $Matches := findRESubmatch $Pattern $Name       -}}
+
+  {{- with $Matches -}}
+    {{- $MatchGroup   := index $Matches    0                                -}}
+    {{- $Input        := index $MatchGroup 0                                -}}
+    {{- $IconName     := index $MatchGroup 1                                -}}
+    {{- $IconVariant  := index $MatchGroup 2                                -}}
+    {{- $iconLibrary  := index $MatchGroup 3                                -}}
+    {{- $combinedName := $IconName                                          -}}
+    {{- $info          = merge $info (dict "Input" $Input "Name" $IconName) -}}
+
+    {{- with $IconVariant -}}
+      {{- $combinedName = printf "%s&%s" $combinedName $IconVariant -}}
+      {{- $info         = merge $info (dict "Variant" $IconVariant) -}}
+    {{- end -}}
+
+    {{- with $iconLibrary -}}
+      {{/*  Just because a library name was parsed doesn't mean it was valid. Retrieve its config  */}}
+      {{- $Library       := partialCached $getIconLibraryConfig $iconLibrary $iconLibrary -}}
+      {{- $libraryStatus := "unknown"                                                     -}}
+
+      {{/*  If the library could be resolved, check if it's enabled.  */}}
+      {{- with $Library -}}
+        {{- range $LibraryName, $LibraryConfig := $Library -}}
+          {{- if eq true $LibraryConfig.enabled -}}
+            {{- $libraryStatus = "enabled" -}}
+          {{- else -}}
+            {{- $libraryStatus = "disabled" -}}
+          {{- end -}}
+
+          {{- $iconLibrary = $LibraryName -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- $info = merge $info (dict "Library" $iconLibrary "LibraryStatus" $libraryStatus) -}}
+    {{- else -}}
+      {{/*  If the library couldn't be resolved, use the default library.  */}}
+      {{- $info = merge $info (dict "Library" $DefaultLibrary "LibraryStatus" "enabled") -}}
+    {{- end -}}
+
+    {{- $info = merge $info (dict "CombinedName" $combinedName) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  Return the canonicalized icon info  */}}
+{{- return $info -}}

--- a/modules/platen/layouts/partials/platen/features/shoelace/utils/resolveIconOptions.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/utils/resolveIconOptions.html
@@ -1,0 +1,99 @@
+{{/*
+    Shoelace Utility Partial: resolveIconOptions
+
+    This partial expects to receive a dict with the following keys:
+
+    - Icon: Mandatory, the information to use when resolving the icon. This can
+      be the name of an icon as a string or a dictionary of icon options.
+    - Page: Optional, the page the icon is being rendered on. Used to register
+      the icon library so it can render correctly.
+    - Position: Optional, improves the warning context. This should be passed
+      when the icon is being resolved from a codeblock render hook.
+
+    If Params.Icon is a string, the partial uses it to resolve the icon. If the
+    value is a dictionary, the partial constructs the resolveable string from
+    the dictionary's `name`, `variant`, and `library` keys.
+
+    This partial returns a dictionary with the following values:
+
+    - name: The canonical name of the icon with the variant, if used.
+    - library: The canonical name of the icon's library.
+
+    If Params.Icon was a dictionary, those values are merged into that value,
+    returning it with the canonicalized name/library.
+
+    If the library resolved to a disabled library or couldn't resolve the
+    library, this partial raises a warning and returns an empty dictionary.
+
+    Because this partial returns a usable map of icon options or an empty map
+    when the icon wasn't resolvable, the caller can use the `with` function over
+    the result of this partial.
+*/}}
+{{/*  Define partials for easier reading/maintaining  */}}
+{{- $parseIconName           := "platen/features/shoelace/utils/parseIconName"           -}}
+{{- $updateUsedIconLibraries := "platen/features/shoelace/utils/updateUsedIconLibraries" -}}
+{{/*  Handle parameters  */}}
+{{- $Params   := .                -}}
+{{- $Page     := $Params.Page     -}}
+{{- $Position := $Params.Position -}}
+{{- $Icon     := $Params.Icon     -}}
+
+{{/*  If Page or Position are passed, give more context on problems  */}}
+{{- $warningSource := " " -}}
+{{- with $Page -}}
+  {{- $warningSource := printf " in '%s' " $Page.File.Path -}}
+{{- end -}}
+{{- with $Position -}}
+  {{- $warningSource := printf " at %s " $Position -}}
+{{- end -}}
+
+{{/*  Define map of sl-icon element attributes to return  */}}
+{{- $iconAttributeMap := dict -}}
+
+{{- if reflect.IsMap $Icon -}}
+  {{- $iconAttributeMap = merge $iconAttributeMap $Icon -}}
+{{- else -}}
+  {{- $iconAttributeMap = merge $iconAttributeMap (dict "name" $Icon) -}}
+{{- end -}}
+
+{{- with $iconAttributeMap.name -}}
+  {{/*  Build the string to parse for the icon's name to get the canonical info  */}}
+  {{- $iconName := $iconAttributeMap.name -}}
+
+  {{- with $iconAttributeMap.variant -}}
+    {{- $iconName = printf "%s&%s" $iconName $iconAttributeMap.variant -}}
+  {{- end -}}
+
+  {{- with $iconAttributeMap.library -}}
+    {{- $iconName = printf "%s@%s" $iconName $iconAttributeMap.library -}}
+  {{- end -}}
+
+  {{/*  Parse the string to get the canonical combined name and library  */}}
+  {{- $IconInfo := partialCached $parseIconName $iconName $iconName -}}
+
+  {{- if eq "enabled" $IconInfo.LibraryStatus -}}
+    {{- $iconAttributeMap = merge $iconAttributeMap (dict "name" $IconInfo.CombinedName) -}}
+
+    {{- if ne "builtin_bootstrap" $IconInfo.Library -}}
+      {{- $iconAttributeMap = merge $iconAttributeMap (dict "library" $IconInfo.Library) -}}
+    {{- end -}}
+
+    {{- partial $updateUsedIconLibraries (dict "Page" $Page "Library" $IconInfo.Library) -}}
+  {{- else if (eq "disabled" $IconInfo.LibraryStatus) -}}
+    {{- warnf "Resolved icon library '%s' for icon '%s'%sis disabled. Ignoring the icon."
+              $IconInfo.Library
+              $iconAttributeMap.name
+              $warningSource
+    -}}
+    {{- $iconAttributeMap = dict -}}
+  {{- else -}}
+    {{- warnf "Couldn't resolve any library for icon '%s'%s. Ignoring the icon."
+              $iconAttributeMap.name
+              $warningSource
+    -}}
+    {{- $iconAttributeMap = dict -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  Return the canonicalized map of attributes  */}}
+{{- return $iconAttributeMap -}}

--- a/modules/platen/layouts/partials/platen/features/shoelace/utils/resolveIconOptions.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/utils/resolveIconOptions.html
@@ -56,6 +56,24 @@
   {{- $iconAttributeMap = merge $iconAttributeMap (dict "name" $Icon) -}}
 {{- end -}}
 
+{{- if and (isset $iconAttributeMap "name") (isset $iconAttributeMap "src") -}}
+  {{- warnf "Specified both src ('%s') and name ('%s') for icon%s - using src."
+      $iconAttributeMap.src
+      $iconAttributeMap.name
+      $warningSource
+  -}}
+
+  {{- $munging := dict -}}
+
+  {{- range $Key, $Value := $iconAttributeMap -}}
+    {{- if not (in (slice "name" "library" "variant") $Key) -}}
+      {{- $munging = merge $munging (dict $Key $Value) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $iconAttributeMap = $munging -}}
+{{- end -}}
+
 {{- with $iconAttributeMap.name -}}
   {{/*  Build the string to parse for the icon's name to get the canonical info  */}}
   {{- $iconName := $iconAttributeMap.name -}}

--- a/modules/platen/layouts/partials/platen/features/shoelace/utils/updateUsedIconLibraries.html
+++ b/modules/platen/layouts/partials/platen/features/shoelace/utils/updateUsedIconLibraries.html
@@ -1,0 +1,31 @@
+{{/*
+    Shoelace Utility Partial: updateUsedIconLibraries
+
+    This partial expects to receive a dict with the following keys:
+
+    - Library: The name of the canonicalized icon library to register as being
+      used on this page.
+    - Page: The page the icon is being rendered on. Default's to the current
+      page if not specified.
+
+    It retrieves the `_usedIconLibraries` key from the page's store and adds
+    the icon library to that list if it's not already included in it.
+
+    If the list doesn't exist, it creates it with the input library as the only
+    item in the list.
+
+    This partial doesn't return any output.
+*/}}
+{{- $Params             := .                                   -}}
+{{- $Page               := $Params.Page    | default page      -}}
+{{- $Library            := $Params.Library                     -}}
+{{- $UsedIconLibraryKey := "_usedIconLibraries"                -}}
+{{- $usedIconLibraries  := $Page.Store.Get $UsedIconLibraryKey -}}
+
+{{- with $usedIconLibraries -}}
+  {{- $usedIconLibraries = $usedIconLibraries | append $Library | uniq -}}
+{{- else -}}
+  {{- $usedIconLibraries = slice $Library -}}
+{{- end -}}
+
+{{- $Page.Store.Set $UsedIconLibraryKey $usedIconLibraries -}}

--- a/modules/platen/layouts/partials/platen/footer/editThisPage.html
+++ b/modules/platen/layouts/partials/platen/footer/editThisPage.html
@@ -1,11 +1,23 @@
 {{/*
-    Docs.Partial: editThisPage
+    Partial: footer/editThisPage
+
+    This partial inserts the "Edit this Page" button in a page footer.
+
+    It expects no input and always operates on the current page.
 */}}
 
+{{/*  Define partials for easier reuse/naming  */}}
+{{- $getKey            := "platen/param/getKey"            -}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+
 {{/* Retrieve settings from the site config */}}
-{{- $RepoConfig   := partialCached "platen/param/getKey" "platen.repository" "platen.repository" -}}
-{{- $repoUrl      := $RepoConfig.url           -}}
-{{- $editPath     := $RepoConfig.edit_path     -}}
+{{- $RepoConfigKey := "platen.repository"                                 -}}
+{{- $RepoConfig    := partialCached $getKey $RepoConfigKey $RepoConfigKey -}}
+{{- $RepoUrl       := $RepoConfig.url                                     -}}
+{{- $EditPath      := $RepoConfig.edit_path                               -}}
+
+{{- $ButtonConfigKey := "platen.display.footer.edit_this_page"                  -}}
+{{- $ButtonConfig    := partialCached $getKey $ButtonConfigKey $ButtonConfigKey -}}
 
 {{/*
   Determine the repository-root-relative path to content directory.
@@ -16,11 +28,11 @@
   1. If neither platen.repository.content_root nor contentDir are set, fall back
      on `content`.
 */}}
-{{- $contentDir     := "content" -}}
+{{- $contentDir := "content" -}}
 {{- with $RepoConfig.content_root -}}
   {{- $contentDir = . -}}
 {{- else -}}
-  {{- with (partialCached "platen/param/getKey" "contentDir" "contentDir") -}}
+  {{- with (partialCached $getKey "contentDir" "contentDir") -}}
     {{- $contentDir = . -}}
     {{- if (hasPrefix $contentDir "../") -}}
       {{- $contentDir = strings.TrimLeft "./" $contentDir  -}}
@@ -29,15 +41,15 @@
 {{- end  -}}
 
 {{/* Retrieve info from the page */}}
-{{- $gitInfo := page.GitInfo -}}
-{{- $file    := page.File    -}}
+{{- $GitInfo := page.GitInfo -}}
+{{- $File    := page.File    -}}
 
 {{/* This partial should only render if the page has git info and the base URL is defined */}}
-{{- $shouldRender := and $file $gitInfo $repoUrl $editPath -}}
+{{- $ShouldRender := and $File $GitInfo $RepoUrl $EditPath $ButtonConfig.enabled -}}
 
-{{- $href := "" -}}
+{{ if $ShouldRender }}
+  {{- $href := "" -}}
 
-{{ if $shouldRender }}
   {{/*
     Munge the file path if needed. This only applies when you have content mounted from a module.
     It loops over the list of mounted paths in platen.repository.mounted_paths and if the file's
@@ -45,19 +57,20 @@
 
     Without this munging, mounted content can't have a functional "edit this page" link.
   */}}
-  {{- $filePath := replace $file.Path "\\" "/" -}}
-  {{- $notYetMunged := true -}}
+  {{- $filePath     := replace $File.Path "\\" "/" -}}
+  {{- $notYetMunged := true                        -}}
+
   {{- range $mountedMap := $RepoConfig.mounted_paths -}}
-    {{/*  {{- $target := default $mountedMap.target $mountedMap.Target -}}  */}}
-    {{/*  {{- $source := default $mountedMap.source $mountedMap.Source -}}  */}}
     {{- if and $notYetMunged (hasPrefix $filePath $mountedMap.target) -}}
       {{- $filePath     = replace $filePath $mountedMap.target $mountedMap.source -}}
-      {{- $notYetMunged = false                             -}}
+      {{- $notYetMunged = false                                                   -}}
     {{- end -}}
   {{- end -}}
+
   {{- if $notYetMunged -}}
     {{- $filePath = printf "%s/%s" $contentDir $filePath -}}
   {{- end -}}
+
   {{/* Build the href for the link depending on the munged file path */}}
   {{- if hasPrefix (upper $filePath) "IGNORE!!" -}}
     {{/* In this case, the content is mounted content and the user chose to ignore it here. */}}
@@ -67,33 +80,66 @@
     {{- $href = $filePath -}}
   {{- else -}}
     {{/* In this case, the content is in this repository. Build the URL. */}}
-    {{- $href = slice $repoUrl $editPath $filePath -}}
+    {{- $href = slice $RepoUrl $EditPath $filePath -}}
     {{- $href = delimit $href "/"                  -}}
   {{- end}}
 
   {{- with $href -}}
-    {{/* Define the attributes for the link. */}}
-    {{- $linkAttributes := slice                                                     -}}
-    {{- $linkAttributes  = $linkAttributes | append `class="flex align-center"`      -}}
-    {{- $linkAttributes  = $linkAttributes | append (printf `href="%s"` $href)       -}}
-    {{- $linkAttributes  = $linkAttributes | append `target="_blank"`                -}}
-    {{- $linkAttributes  = $linkAttributes | append `rel="noopener"`                 -}}
-    {{- $linkAttributes  = partial "platen/utils/getSafeAttributes" $linkAttributes  -}}
+    {{- if $ButtonConfig.use_legacy -}}
+      {{- partial "platen/footer/editThisPage/legacy" $href -}}
+    {{- else -}}
+      {{/*  Make sure the custom-handled options aren't sent as attributes  */}}
+      {{- $SkipOptions := slice "use_legacy" "enabled" "classes" "prefix_icon" "suffix_icon" -}}
+      
+      {{/*  Initialize the attribute list with the href  */}}
+      {{- $attributes := slice (printf `href="%s"`  $href) -}}
 
-    {{/* Define the attributes for the image. */}}
-    {{- $imageAttributes := slice                                                     -}}
-    {{- $src             := "svg/edit.svg" | relURL                                   -}}
-    {{- $imageAttributes  = $imageAttributes | append (printf `src="%s"` $src)        -}}
-    {{- $imageAttributes  = $imageAttributes | append `class="platen-icon"`           -}}
-    {{- $imageAttributes  = $imageAttributes | append `alt="Edit"`                    -}}
-    {{- $imageAttributes  = partial "platen/utils/getSafeAttributes" $imageAttributes -}}
+      {{/*  Handle the button's classes  */}}
+      {{- $classes := slice "platen-btn" -}}
+      {{- with $ButtonConfig.classes -}}
+        {{- $classes = union $classes $ButtonConfig.classes -}}
+      {{- end -}}
+      {{- $classes         = delimit $classes " "                 -}}
+      {{- $ClassAttribute := printf `class="%s"` $classes         -}}
+      {{- $attributes     := $attributes | append $ClassAttribute -}}
 
-    {{/* Render */}}
-    <div>
-      <a {{ $linkAttributes }}>
-        <img {{ $imageAttributes }}/>
-        <span>{{ i18n "Edit this page" }}</span>
-      </a>
-    </div>
+      {{/*  Handle remaining attributes  */}}
+      {{- range $Name, $Value := $ButtonConfig -}}
+        {{- if not (in $SkipOptions $Name) -}}
+          {{- $Attribute := printf `%s="%s"` $Name (print $Value) -}}
+          {{- $attributes = $attributes | append $Attribute       -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{/*  Turn the slice into insertable attributes  */}}
+      {{- $attributeParams  := dict "Attributes" $attributes "IndentCount" 13 -}}
+      {{- $ButtonAttributes := partial $getSafeAttributes $attributeParams    -}}
+
+      {{/*  Get the label for the button  */}}
+      {{- $Label := i18n "Edit this page" | page.RenderString -}}
+
+      {{- partial "platen/features/shoelace/templates/button" (
+            dict
+            "Page"       page
+            "Attributes" $ButtonAttributes
+            "Label"      $Label
+            "PrefixIcon" $ButtonConfig.prefix_icon
+            "SuffixIcon" $ButtonConfig.suffix_icon
+          )
+      -}}
+    {{- end -}}
   {{- end -}}
+{{- end -}}
+
+{{- define "partials/platen/footer/editThisPage/legacy" -}}
+  {{- $Href := .                       | safeHTMLAttr -}}
+  {{- $Src  := "svg/edit.svg" | relURL | safeHTMLAttr -}}
+
+  {{/* Render */}}
+  <div>
+    <a class="flex align-center" href="{{ $Href }}" target="_blank" rel="noopener">
+      <img class="platen-cion" src="{{ $Src }}" alt="Edit"/>
+      <span>{{ i18n "Edit this page" }}</span>
+    </a>
+  </div>
 {{- end -}}

--- a/modules/platen/layouts/partials/platen/footer/lastEditedOn.html
+++ b/modules/platen/layouts/partials/platen/footer/lastEditedOn.html
@@ -1,50 +1,107 @@
 {{/*
-    Docs.Partial: editThisPage
+    Partial: footer/lastEditedOn
+
+    This partial inserts the "Last Edited On" button in a page footer.
+
+    It expects no input and always operates on the current page.
 */}}
 
+{{/*  Define partials for easier reuse/naming  */}}
+{{- $getKey            := "platen/param/getKey"            -}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+{{- $getFormattedDate  := "platen/utils/getFormattedDate"  -}}
+
 {{/* Retrieve settings from the site config */}}
-{{- $PlatenConfig := partialCached "platen/param/getKey" "platen" "platen" -}}
-{{- $repoUrl      := $PlatenConfig.repository.url     -}}
-{{- $dateFormat   := $PlatenConfig.display.date_format -}}
+{{- $ConfigKey    := "platen"                                                -}}
+{{- $PlatenConfig := partialCached $getKey $ConfigKey $ConfigKey             -}}
+{{- $RepoUrl      := $PlatenConfig.repository.url                            -}}
+{{- $CommitPath   := $PlatenConfig.repository.commit_path | default "commit" -}}
+{{- $DateFormat   := $PlatenConfig.display.date_format                       -}}
+{{- $ButtonConfig := $PlatenConfig.display.footer.last_edited_on             -}}
 
 {{/* Retrieve info from the page */}}
-{{- $gitInfo := page.GitInfo -}}
+{{- $GitInfo := page.GitInfo -}}
 
 {{/* This partial should only render if the page has git info and the base URL is defined */}}
-{{- $shouldRender := and $gitInfo $repoUrl -}}
+{{- $ShouldRender := and $GitInfo $RepoUrl $ButtonConfig.enabled -}}
 
-{{ if $shouldRender }}
+{{ if $ShouldRender }}
   {{/* Define the commit path and date based on site config and git info */}}
-  {{- $commitPath     := default "commit" $PlatenConfig.repository.commit_path         -}}
-  {{- $dateParams     := dict    "Date" $gitInfo.AuthorDate.Local "Format" $dateFormat -}}
-  {{- $date           := partial "platen/utils/getFormattedDate" $dateParams           -}}
+  {{- $LastEdited := $GitInfo.AuthorDate.Local                                 -}}
+  {{- $DateParams := dict    "Date" $LastEdited "Format" $DateFormat           -}}
+  {{- $Date       := partial $getFormattedDate $DateParams                     -}}
+  {{- $href       := slice $RepoUrl $CommitPath $GitInfo.Hash                  -}}
+  {{- $href       := delimit $href "/"                                         -}}
+  {{- $title      := slice (i18n "Last modified by") $GitInfo.AuthorName $Date -}}
+  {{- $title      := delimit $title " " " | "                                  -}}
 
-  {{/* Define the attributes for the link. */}}
-  {{- $linkAttributes := slice                                                     -}}
-  {{- $linkAttributes  = $linkAttributes | append `class="flex align-center"`      -}}
-  {{- $href           := slice $repoUrl $commitPath $gitInfo.Hash                  -}}
-  {{- $href           := delimit $href "/"                                         -}}
-  {{- $linkAttributes  = $linkAttributes | append (printf `href="%s"` $href)       -}}
-  {{- $title          := slice (i18n "Last modified by") $gitInfo.AuthorName $date -}}
-  {{- $title          := delimit $title " " " | "                                  -}}
-  {{- $linkAttributes  = $linkAttributes | append (printf `title="%s"` $title)     -}}
-  {{- $linkAttributes  = $linkAttributes | append `target="_blank"`                -}}
-  {{- $linkAttributes  = $linkAttributes | append `rel="noopener"`                 -}}
-  {{- $linkAttributes  = partial "platen/utils/getSafeAttributes" $linkAttributes  -}}
+  {{- if $ButtonConfig.use_legacy -}}
+    {{- $LegacyParams := dict "Date" $Date "Href" $href "Title" $title -}}
+    {{- partial "platen/footer/lastEditedOn/legacy" -}}
+  {{- else -}}
+    {{- $SkipOptions := slice "use_legacy" "enabled" "classes" "prefix_icon" "suffix_icon" "show_elapsed" -}}
 
-  {{/* Define the attributes for the image. */}}
-  {{- $imageAttributes := slice                                                     -}}
-  {{- $src             := "svg/calendar.svg" | relURL                               -}}
-  {{- $imageAttributes  = $imageAttributes | append (printf `src="%s"` $src)        -}}
-  {{- $imageAttributes  = $imageAttributes | append `class="platen-icon"`           -}}
-  {{- $imageAttributes  = $imageAttributes | append `alt="Calendar"`                -}}
-  {{- $imageAttributes  = partial "platen/utils/getSafeAttributes" $imageAttributes -}}
+    {{/*  Initialize the attribute list with the href  */}}
+    {{- $attributes  := slice (printf `href="%s"`  $href) -}}
 
+    {{/*  Handle the button's classes  */}}
+    {{- $classes := slice "platen-btn" }}
+    {{- with $ButtonConfig.classes -}}
+      {{- $classes = union $classes $ButtonConfig.classes -}}
+    {{- end -}}
+    {{- $classes         = delimit $classes " "                 -}}
+    {{- $ClassAttribute := printf `class="%s"` $classes         -}}
+    {{- $attributes     := $attributes | append $ClassAttribute -}}
+
+    {{/*  Handle remaining attributes  */}}
+    {{- range $Name, $Value := $ButtonConfig -}}
+      {{- if not (in $SkipOptions $Name) -}}
+        {{- $Attribute := printf `%s="%s"` $Name (print $Value) -}}
+        {{- $attributes = $attributes | append $Attribute       -}}
+      {{- end -}}
+    {{- end -}}
+
+    {{/*  Turn the slice into insertable attributes  */}}
+    {{- $attributeParams  := dict "Attributes" $attributes "IndentCount" 15 -}}
+    {{- $ButtonAttributes := partial $getSafeAttributes $attributeParams    -}}
+
+    {{- $label := $Date -}}
+    {{- if eq true $ButtonConfig.show_elapsed -}}
+      {{- $label = printf `<sl-relative-time date="%s"></sl-relative-time>` $LastEdited -}}
+    {{- end -}}
+
+    {{- $ButtonParams := dict "Page"       page
+                              "Attributes" $ButtonAttributes
+                              "Label"      $label
+                              "PrefixIcon" $ButtonConfig.prefix_icon
+                              "SuffixIcon" $ButtonConfig.suffix_icon
+    -}}
+    {{- $TemplateParams := dict "ButtonParams" $ButtonParams "Title" $title -}}
+    {{- partial "platen/footer/lastEditedOn/default" $TemplateParams -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "partials/platen/footer/lastEditedOn/default" -}}
+  {{- $Params       := .                    -}}
+  {{- $ButtonParams := $Params.ButtonParams -}}
+  {{- $Title        := $Params.Title        -}}
+
+  <sl-tooltip hoist content="{{ $Title}}">
+    {{ partial "platen/features/shoelace/templates/button" $ButtonParams }}
+  </sl-tooltip>
+{{- end -}}
+
+{{- define "partials/platen/footer/lastEditedOn/legacy" -}}
+  {{- $Params := .                                          -}}
+  {{- $Date   := $Params.Date                | safeHTML     -}}
+  {{- $Href   := $Params.Href                | safeHTMLAttr -}}
+  {{- $Title  := $Params.Title               | safeHTMLAttr -}}
+  {{- $Src    := "svg/calendar.svg" | relURL | safeHTMLAttr -}}
   {{/* Render */}}
   <div>
-    <a {{ $linkAttributes }}>
-      <img {{ $imageAttributes }}/>
-      <span>{{ $date }}</span>
+    <a class="flex align-center" href="{{ $Href }}" title="{{ $Title}}" target="_blank" rel="noopener">
+      <img src="{{ $Src}}" class="platen-icon" alt="Calendar"/>
+      <span>{{ $Date }}</span>
     </a>
   </div>
 {{- end -}}

--- a/modules/platen/layouts/partials/platen/header/menuControl.html
+++ b/modules/platen/layouts/partials/platen/header/menuControl.html
@@ -1,23 +1,43 @@
 {{/*
-    Docs.Partial: menuControl
+    Header Partial: menuControl
+
+    This partial displays the button visitors can click on mobile to display
+    the site menu.
+
+    If `platen.display.mobile.menu_control.use_legacy` is set to `true`, it
+    displays an `<sl-icon-button>` with a tooltip that explains what the button
+    does. The button and tooltip can be configured in the site settings.
+
+    If `platen.display.mobile.menu_control.use_legacy` is set to `false`, it
+    displays `static/svg/menu.svg` as an image.
 */}}
 
-{{/* Get the menu icon */}}
-{{- $src := "svg/menu.svg" | relURL -}}
+{{/*  Define partials for easier reuse/naming  */}}
+{{- $getKey            := "platen/param/getKey"            -}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
 
-{{/* Define the attributes for the label element */}}
-{{- $labelAttributes := slice                                                     -}}
-{{- $labelAttributes  = $labelAttributes | append `for="menu-control"`            -}}
-{{- $labelAttributes  = partial "platen/utils/getSafeAttributes" $labelAttributes -}}
+{{/*  Retrieve options from the site config  */}}
+{{- $Key    := "platen.display.mobile.menu_control" -}}
+{{- $Config := partialCached $getKey $Key $Key      -}}
 
-{{/* Define the attributes for the image element */}}
-{{- $imageAttributes := slice                                                     -}}
-{{- $imageAttributes  = $imageAttributes | append (printf `src="%s"` $src)        -}}
-{{- $imageAttributes  = $imageAttributes | append `class="platen-icon"`           -}}
-{{- $imageAttributes  = $imageAttributes | append `alt="Menu"`                    -}}
-{{- $imageAttributes  = partial "platen/utils/getSafeAttributes" $imageAttributes -}}
+{{- $template       := "platen/features/shoelace/templates/iconButton" -}}
+{{- $templateParams := dict                                            -}}
+
+{{- if eq true $Config.use_legacy -}}
+  {{- $template = "platen/header/menuControl/legacy" -}}
+{{- else -}}
+  {{- $DefaultLabel  := "Show site menu"                                     -}}
+  {{- $OnClickOption := dict  "onClick" "Platen.showSiteMenu()"              -}}
+  {{- $ButtonOptions := merge $Config   $OnClickOption                       -}}
+  {{- $templateParams = dict  "Button"  $ButtonOptions "Label" $DefaultLabel -}}
+{{- end -}}
 
 {{/* Render */}}
-<label {{ $labelAttributes }} >
-  <img {{ $imageAttributes }} />
+<label for="menu-control">
+  {{ partial $template $templateParams }}
 </label>
+
+{{- define "partials/platen/header/menuControl/legacy" -}}
+  {{- $Src := "svg/menu.svg" | relURL | safeHTMLAttr -}}
+  <img src="{{ $Src}}" class="platen-icon" alt="Menu"/>
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/header/title.html
+++ b/modules/platen/layouts/partials/platen/header/title.html
@@ -1,25 +1,48 @@
 {{/*
-    Docs.Partial: title
+    Partial: header/title
+
+    This partial handles displaying a page's title in the header section for
+    the page.
+
+    This partial doesn't expect any input, it always operates on the current
+    page.
+
+    If the `platen.display.header.title_as_heading` key is set to `true` in the
+    site configuration or the page's front matter has the
+    `platen.display_title.as_heading` option set to `true`, the page's title
+    is rendered as an H1.
+
+    Otherwise, it's rendered in a <strong> element.
 */}}
 
-{{/* Get the title text */}}
-{{- $TitleParams := dict "Context" page "ForHeader" true         -}}
-{{- $TitleText   := partial "platen/utils/getTitle" $TitleParams -}}
-
+{{/*  Define partials for easier reuse/maintenance  */}}
+{{- $getSafeAttributes  := "platen/utils/getSafeAttributes" -}}
+{{- $getTitle           := "platen/utils/getTitle"          -}}
+{{- $getDisplayTitle    := "platen/utils/getDisplayTitle"   -}}
+{{/*  Define the lookup keys for easier renaming/maintenance  */}}
+{{- $ConfigKey      := "platen.display.header.title_as_heading" -}}
+{{- $ParamKey       := "platen.display_title.as_heading"        -}}
+{{- $LegacyParamKey := "platen.title_as_heading"                -}}
 {{/* Determine the element tag. */}}
 {{- $ShouldBeHeader := partial "platen/param/resolve" (
-      dict "Config"  "platen.display.header.title_as_heading"
-           "Param"   "platen.title_as_heading"
+      dict "Config"  $ConfigKey
+           "Param"   (slice $ParamKey $LegacyParamKey)
            "Context" page
            "Default" false
     )
 -}}
 {{- $ElementTag := cond $ShouldBeHeader "h1" "strong" -}}
 
+{{/* Get the title text */}}
+{{- $params       := dict "Context" page "ForHeader" true  -}}
+{{- $Title        := partial $getTitle $params             -}}
+{{- $params        = dict "Page" page "Title" $Title       -}}
+{{- $DisplayTitle := partial $getDisplayTitle $params      -}}
+
 {{/* define the attributes for the tag */}}
 {{- $openTagAttributes := slice -}}
 {{- if $ShouldBeHeader -}}
-  {{- $ID               := urlize (lower $TitleText)                          -}}
+  {{- $ID               := urlize (lower $Title)                              -}}
   {{- $openTagAttributes = $openTagAttributes | append (printf `id="%s"` $ID) -}}
 {{- end -}}
 {{- $openTagAttributes = partial "platen/utils/getSafeAttributes" $openTagAttributes -}}
@@ -28,5 +51,5 @@
 
 {{/* Render */}}
 {{ $openTag }}
-  {{- $TitleText -}}
+  {{- $DisplayTitle -}}
 {{ $closeTag }}

--- a/modules/platen/layouts/partials/platen/header/tocControl.html
+++ b/modules/platen/layouts/partials/platen/header/tocControl.html
@@ -1,31 +1,49 @@
 {{/*
-    Docs.Partial: menuControl
+    Header Partial: tocControl
+
+    This partial displays the button visitors can click on mobile to display
+    the table of contents for a page.
+
+    If `platen.display.mobile.toc_control.use_legacy` is set to `true`, it
+    displays an `<sl-icon-button>` with a tooltip that explains what the button
+    does. The button and tooltip can be configured in the site settings.
+
+    If `platen.display.mobile.toc_control.use_legacy` is set to `false`, it
+    displays `static/svg/toc.svg` as an image.
 */}}
 
+{{/*  Define partials for easier reuse/naming  */}}
+{{- $getKey            := "platen/param/getKey"            -}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+{{- $shouldRenderToC   := "platen/utils/shouldRenderToC"   -}}
+
 {{/* Determine if the TOC menu should be rendered */}}
-{{- $ShouldRender := partial "platen/param/resolve" (
-  dict "Config"  "platen.display.table_of_contents.render"
-       "Param"   "platen.table_of_contents.render"
-       "Context" page
-       "Default" true
-) -}}
+{{- $ShouldRender := partialCached $shouldRenderToC page page -}}
 
-{{/* Get the menu icon */}}
-{{- $src := "svg/toc.svg" | relURL -}}
+{{/*  Retrieve options from the site config  */}}
+{{- $Key    := "platen.display.mobile.toc_control" -}}
+{{- $Config := partialCached $getKey $Key $Key     -}}
 
-{{/* Define the attributes for the label element */}}
-{{- $labelAttributes := slice                                                     -}}
-{{- $labelAttributes  = $labelAttributes | append `for="toc-control"`             -}}
-{{- $labelAttributes  = partial "platen/utils/getSafeAttributes" $labelAttributes -}}
+{{- $template       := "platen/features/shoelace/templates/iconButton" -}}
+{{- $templateParams := dict                                            -}}
 
-{{/* Define the attributes for the image element */}}
-{{- $imageAttributes := slice                                                     -}}
-{{- $imageAttributes  = $imageAttributes | append (printf `src="%s"` $src)        -}}
-{{- $imageAttributes  = $imageAttributes | append `class="platen-icon"`           -}}
-{{- $imageAttributes  = $imageAttributes | append `alt="Table of Contents"`       -}}
-{{- $imageAttributes  = partial "platen/utils/getSafeAttributes" $imageAttributes -}}
+{{- if eq true $Config.use_legacy -}}
+  {{- $template = "platen/header/tocControl/legacy" -}}
+{{- else -}}
+  {{- $DefaultLabel  := "Toggle table of contents"                           -}}
+  {{- $OnClickOption := dict  "onClick" "Platen.toggleTableOfContents()"     -}}
+  {{- $ButtonOptions := merge $Config   $OnClickOption                       -}}
+  {{- $templateParams = dict  "Button"  $ButtonOptions "Label" $DefaultLabel -}}
+{{- end -}}
 
 {{/* Render */}}
-<label {{ $labelAttributes }} >
-  {{ if $ShouldRender }}<img {{ $imageAttributes }} />{{ end }}
+<label for="toc-control" >
+  {{ if $ShouldRender -}}
+    {{- partial $template $templateParams -}}
+  {{- end }}
 </label>
+
+{{- define "partials/platen/header/tocControl/legacy" -}}
+  {{- $Src := "svg/toc.svg" | relURL | safeHTMLAttr -}}
+  <img src="{{ $Src}}" class="platen-icon" alt="Table of Contents"/>
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/htmlHead.html
+++ b/modules/platen/layouts/partials/platen/htmlHead.html
@@ -34,6 +34,8 @@
   {{- end -}}
 {{- end -}}
 
+{{ partialCached "platen/htmlHead/tocScript" "cache" "cache" }}
+
 {{- template "_internal/google_analytics.html" page -}}
 
 {{ partial "platen/htmlHead/rssLink" }}

--- a/modules/platen/layouts/partials/platen/htmlHead.html
+++ b/modules/platen/layouts/partials/platen/htmlHead.html
@@ -16,6 +16,8 @@
 
 {{ partial "platen/htmlHead/siteStyleLink" page }}
 
+{{ partialCached "platen/htmlHead/siteModuleScript" "cache" "cache" }}
+
 {{ range $Feature, $Settings := $PlatenConfig.features -}}
   {{- if $Settings.enabled -}}
     {{- with $Settings.partials.header -}}

--- a/modules/platen/layouts/partials/platen/htmlHead/siteModuleScript.html
+++ b/modules/platen/layouts/partials/platen/htmlHead/siteModuleScript.html
@@ -1,0 +1,6 @@
+{{- $Module  := partialCached "platen/utils/getModule" "cache" "cache" -}}
+{{/*  Render  */}}
+<script type="module">
+  import * as Platen  from '{{ $Module.RelPermalink }}'
+  window.Platen = Platen
+</script>

--- a/modules/platen/layouts/partials/platen/htmlHead/tocScript.html
+++ b/modules/platen/layouts/partials/platen/htmlHead/tocScript.html
@@ -1,0 +1,9 @@
+<script type="module">
+  ['TableOfContents', 'TableOfContentsMobile'].forEach(id => {
+    Platen.stopPropagationInTree(
+      `nav#${id} sl-tree a`,
+      `nav#${id} sl-tree`,
+      'click'
+    )
+  })
+</script>

--- a/modules/platen/layouts/partials/platen/markup/_default/heading.html
+++ b/modules/platen/layouts/partials/platen/markup/_default/heading.html
@@ -1,9 +1,74 @@
-{{- $Input  := .                        -}}
-{{- $Level  := $Input.Level             -}}
-{{- $Anchor := $Input.Anchor | safeURL  -}}
-{{- $Text   := $Input.Text   | safeHTML -}}
+{{- $IconTemplate       := "platen/features/shoelace/templates/icon"  -}}
+{{- $getEnabledFeatures := "platen/utils/features/getEnabledFeatures" -}}
+{{/*  Handle Input  */}}
+{{- $Input      := .                            -}}
+{{- $Page       := $Input.Page                  -}}
+{{- $Level      := $Input.Level                 -}}
+{{- $Anchor     := $Input.Anchor     | safeURL  -}}
+{{- $Text       := $Input.Text       | safeHTML -}}
+{{- $Attributes := $Input.Attributes            -}}
+{{/*  Build the heading info without the page  */}}
+{{- $Heading    := dict "Level"      $Level
+                        "Text"       $Text
+                        "Anchor"     $Anchor
+                        "Attributes" $Attributes
+-}}
 
-<h{{ $Level }} id="{{ $Anchor }}">
-  {{ $Text }}
+{{/*  When the page is available, update the stored headings.  */}}
+{{- with $Page -}}
+  {{- $headings := $Page.Store.Get "_HeadingMap" | default (dict)  -}}
+  {{- $headings  = merge $headings (dict (print $Anchor) $Heading) -}}
+  {{- $Page.Store.Set "_HeadingMap" $headings                      -}}
+{{- end -}}
+
+{{- $attributeList := slice (printf `id="%s"` $Anchor) -}}
+
+{{- with $Classes := $Attributes.class -}}
+  {{- $ClassAttribute := printf `class="%s"` $Classes            -}}
+  {{- $attributeList   = $attributeList | append $ClassAttribute -}}
+{{- end -}}
+
+{{/*  Determine whether the anchor should be skipped  */}}
+{{- $NoAnchor := $Attributes.no_anchor | default false -}}
+
+{{/*  Determine whther the icons should be handled  */}}
+{{- $EnabledFeatures := partialCached $getEnabledFeatures "Cache" "Cache" -}}
+{{- $ShoelaceEnabled := in $EnabledFeatures "shoelace"                    -}}
+{{- $PrefixIcon      := cond $ShoelaceEnabled $Attributes.prefix_icon ""  -}}
+{{- $SuffixIcon      := cond $ShoelaceEnabled $Attributes.suffix_icon ""  -}}
+
+{{/*  These attributes are intentionally handled, so skip adding them.  */}}
+{{- $SkipAttributes := slice
+      "class"
+      "id"
+      "no_anchor"
+      "suffix_icon"
+      "prefix_icon"
+-}}
+
+{{/*  Add any non-handled attributes to the heading element  */}}
+{{- range $Name, $Value := $Attributes -}}
+  {{- if and (not (in $SkipAttributes $Name)) (not (hasPrefix $Name "toc_")) -}}
+    {{- $Entry        := printf `%s="%s"` $Name (print $Value) -}}
+    {{- $attributeList = $attributeList | append $Entry        -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  Build the attribute list, then render the heading  */}}
+{{- $attributeList = delimit $attributeList " " | safeHTMLAttr -}}
+
+<h{{ $Level }} {{ $attributeList }}>
+  {{- with $PrefixIcon }}
+    {{ partial $IconTemplate (dict "Page" $Page "Icon" $PrefixIcon) }}
+  {{ end -}}
+
+  {{ $Text | safeHTML }}
+
+  {{- with $SuffixIcon }}
+    {{ partial $IconTemplate (dict "Page" $Page "Icon" $SuffixIcon) }}
+  {{ end -}}
+
+  {{- if not $NoAnchor }}
   <a class="anchor" href="#{{ $Anchor }}">#</a>
+  {{- end }}
 </h{{ $Level }}>

--- a/modules/platen/layouts/partials/platen/markup/alerts/_canonicalize.html
+++ b/modules/platen/layouts/partials/platen/markup/alerts/_canonicalize.html
@@ -34,13 +34,16 @@
       returns them as a single space-delimited string, marked as safe for
       insertion into HTML attributes.
 */}}
-{{- $mungeHeadingLevel    := "platen/utils/mungeHeadingLevel"    -}}
-{{- $getLeadTrimmedText   := "platen/utils/getLeadTrimmedText"   -}}
-{{- $getMergedClasses     := "platen/utils/getMergedClasses"     -}}
-{{- $getMergedMap         := "platen/utils/getMergedMap"         -}}
-{{- $getMergedStyleOption := "platen/utils/getMergedStyleOption" -}}
-{{- $getPrettyRender      := "platen/utils/getPrettyRender"      -}}
-{{- $getSafeAttributes    := "platen/utils/getSafeAttributes"    -}}
+{{- $mungeHeadingLevel       := "platen/utils/mungeHeadingLevel"                         -}}
+{{- $getLeadTrimmedText      := "platen/utils/getLeadTrimmedText"                        -}}
+{{- $getMergedClasses        := "platen/utils/getMergedClasses"                          -}}
+{{- $getMergedMap            := "platen/utils/getMergedMap"                              -}}
+{{- $getMergedStyleOption    := "platen/utils/getMergedStyleOption"                      -}}
+{{- $getPrettyRender         := "platen/utils/getPrettyRender"                           -}}
+{{- $getSafeAttributes       := "platen/utils/getSafeAttributes"                         -}}
+{{- $parseIconName           := "platen/features/shoelace/utils/parseIconName"           -}}
+{{- $updateUsedIconLibraries := "platen/features/shoelace/utils/updateUsedIconLibraries" -}}
+{{- $resolveIconOptions      := "platen/features/shoelace/utils/resolveIconOptions"      -}}
 {{/*  Define the template folder and default template for this markup  */}}
 {{- $TemplateFolder := "platen/markup/alerts/templates" -}}
 {{- $template       := "default"                        -}}
@@ -324,18 +327,10 @@
     Handle the icon attributes - if an icon is defined, it should at least get
     the name attribute. If this dict stays empty, no icon gets added.
 */}}
-{{- $iconAttributeMap  := dict -}}
-{{/*
-    The icon can be specified as either a string or a map for more control. If
-    the icon is a map, use the map directly for the attributes. If it's a
-    string, use the value for the `name` key in the attribute map.
-*/}}
+{{- $icon := dict -}}
+{{/*  The icon can be specified as either a string or a map for more control.  */}}
 {{- with $options.icon -}}
-  {{- if reflect.IsMap $options.icon -}}
-    {{- $iconAttributeMap = merge $iconAttributeMap $options.icon -}}
-  {{- else -}}
-    {{- $iconAttributeMap = merge $iconAttributeMap (dict "name" $options.icon) -}}
-  {{- end -}}
+  {{- $icon = $options.icon -}}
 {{- end -}}
 {{/*
     If it should use default icons, try to use that unless an icon was specified
@@ -343,10 +338,10 @@
 */}}
 {{- if $options.use_default_icons -}}
   {{- $ConfigIcon := index $Config.icons $options.variant -}}
-  {{- with $iconAttributeMap.name -}}
+  {{- with $icon -}}
     {{/*  Nothing to do, already set.  */}}
   {{- else -}}
-    {{- $iconAttributeMap = merge $iconAttributeMap (dict "name" $ConfigIcon) -}}
+    {{- $icon = $ConfigIcon -}}
   {{- end -}}
 {{- end -}}
 {{/*
@@ -354,16 +349,26 @@
     wasn't, error only if the markup expected to use the default icons and the
     icon for this alert's variant couldn't be found.
 */}}
-{{- with $iconAttributeMap -}}
-  {{- $iconAttributes := slice -}}
+{{- with $icon -}}
+  {{/*
+      Resolve the icon's options into a map of attributes.
+
+      If the icon is valid, this returns the map of options for it and marks
+      the icon's library for registration automatically.
+
+      If the icon is invalid, this returns an empty map and raises a warning.
+  */}}
+  {{- $resolveIconParams := dict "Page" $Page "Position" $Position "Icon" $icon        -}}
+  {{- $iconAttributeMap  := partialCached $resolveIconOptions $resolveIconParams $icon -}}
   {{/*
       Loop over the defined keys, turning them into attribute declarations. We
       always print the value before insertion, because HTML attributes expect
       the values as strings.
   */}}
+  {{- $iconAttributes := slice -}}
   {{- range $Key, $Value := $iconAttributeMap -}}
     {{- $IconAttribute := printf `%s="%s"` $Key (print $Value)     -}}
-    {{- $iconAttributes = $iconAttributes | append $IconAttribute -}}
+    {{- $iconAttributes = $iconAttributes | append $IconAttribute  -}}
   {{- end -}}
 
   {{/*

--- a/modules/platen/layouts/partials/platen/markup/buttons/_canonicalize.html
+++ b/modules/platen/layouts/partials/platen/markup/buttons/_canonicalize.html
@@ -34,11 +34,12 @@
       returns them as a single space-delimited string, marked as safe for
       insertion into HTML attributes.
 */}}
-{{- $mungeHeadingLevel  := "platen/utils/mungeHeadingLevel"    -}}
-{{- $getLeadTrimmedText := "platen/utils/getLeadTrimmedText"   -}}
-{{- $getMergedClasses   := "platen/utils/getMergedClasses"     -}}
-{{- $getPrettyRender    := "platen/utils/getPrettyRender"      -}}
-{{- $getSafeAttributes  := "platen/utils/getSafeAttributes"    -}}
+{{- $mungeHeadingLevel  := "platen/utils/mungeHeadingLevel"                    -}}
+{{- $getLeadTrimmedText := "platen/utils/getLeadTrimmedText"                   -}}
+{{- $getMergedClasses   := "platen/utils/getMergedClasses"                     -}}
+{{- $getPrettyRender    := "platen/utils/getPrettyRender"                      -}}
+{{- $getSafeAttributes  := "platen/utils/getSafeAttributes"                    -}}
+{{- $resolveIconOptions := "platen/features/shoelace/utils/resolveIconOptions" -}}
 {{/*  Define the template folder and default template for this markup  */}}
 {{- $TemplateFolder := "platen/markup/buttons/templates/link" -}}
 {{- $template       := "default"                              -}}
@@ -255,18 +256,19 @@
   {{- end -}}
 
   {{- with $options.label_icon -}}
-    {{- $labelAttributes := slice -}}
-    {{- if reflect.IsMap $options.label_icon -}}
-      {{- range $AttributeName, $AttributeValue := $options.label_icon -}}
-        {{- $labelAttributes = $labelAttributes | append (printf `%s="%s"` $AttributeName (print $AttributeValue)) -}}
-      {{- end -}}
-    {{- else -}}
-      {{- $labelAttributes = $labelAttributes | append (printf `name="%s"` $options.label_icon) -}}
+    {{- $resolveIconParams := dict "Page" $Page "Position" $Position "Icon" $options.label_icon        -}}
+    {{- $iconAttributeMap  := partialCached $resolveIconOptions $resolveIconParams $options.label_icon -}}
+
+    {{- $iconAttributes := slice -}}
+    {{- range $Key, $Value := $iconAttributeMap -}}
+      {{- $IconAttribute   := printf `%s="%s"` $Key (print $Value)     -}}
+      {{- $iconAttributes   = $iconAttributes | append $IconAttribute  -}}
     {{- end -}}
-    {{- $attributeParams := dict "Attributes" $labelAttributes "IndentCount" 27          -}}
-    {{- $labelAttributes  = partial "platen/utils/getSafeAttributes" $attributeParams    -}}
-    {{- $Label    := printf `<sl-icon %s></sl-icon>` $labelAttributes                    -}}
-    {{- $canonical = merge $canonical (dict "Label" $Label)                              -}}
+
+    {{- $attributeParams := dict "Attributes" $iconAttributes "IndentCount" 27           -}}
+    {{- $labelAttributes := partial "platen/utils/getSafeAttributes" $attributeParams    -}}
+    {{- $Label           := printf `<sl-icon %s></sl-icon>` $labelAttributes             -}}
+    {{- $canonical        = merge $canonical (dict "Label" $Label)                       -}}
     {{- if isset $options "circle" -}}
       {{- $attributes = $attributes | append (printf `circle="%v"` $options.circle) -}}
     {{- end -}}
@@ -291,12 +293,12 @@
   {{/*  Handle the prefix  */}}
   {{- $prefixAttributes := slice -}}
   {{- with $options.prefix_icon -}}
-    {{- if reflect.IsMap $options.prefix_icon -}}
-      {{- range $AttributeName, $AttributeValue := $options.prefix_icon -}}
-        {{- $prefixAttributes = $prefixAttributes | append (printf `%s="%s"` $AttributeName (print $AttributeValue)) -}}
-      {{- end -}}
-    {{- else -}}
-      {{- $prefixAttributes = $prefixAttributes | append (printf `name="%s"` $options.prefix_icon) -}}
+    {{- $resolveIconParams  := dict "Page" $Page "Position" $Position "Icon" $options.prefix_icon        -}}
+    {{- $iconAttributeMap   := partialCached $resolveIconOptions $resolveIconParams $options.prefix_icon -}}
+
+    {{- range $Key, $Value := $iconAttributeMap -}}
+      {{- $IconAttribute   := printf `%s="%s"` $Key (print $Value)       -}}
+      {{- $prefixAttributes = $prefixAttributes | append $IconAttribute  -}}
     {{- end -}}
   {{- end -}}
   {{- with $prefixAttributes -}}
@@ -308,12 +310,12 @@
   {{/*  Handle the suffix  */}}
   {{- $suffixAttributes := slice -}}
   {{- with $options.suffix_icon -}}
-    {{- if reflect.IsMap $options.suffix_icon -}}
-      {{- range $AttributeName, $AttributeValue := $options.suffix_icon -}}
-        {{- $suffixAttributes = $suffixAttributes | append (printf `%s="%s"` $AttributeName (print $AttributeValue)) -}}
-      {{- end -}}
-    {{- else -}}
-      {{- $suffixAttributes = $suffixAttributes | append (printf `name="%s"` $options.suffix_icon) -}}
+    {{- $resolveIconParams  := dict "Page" $Page "Position" $Position "Icon" $options.suffix_icon        -}}
+    {{- $iconAttributeMap   := partialCached $resolveIconOptions $resolveIconParams $options.suffix_icon -}}
+
+    {{- range $Key, $Value := $iconAttributeMap -}}
+      {{- $IconAttribute   := printf `%s="%s"` $Key (print $Value)       -}}
+      {{- $suffixAttributes = $suffixAttributes | append $IconAttribute  -}}
     {{- end -}}
   {{- end -}}
   {{- with $suffixAttributes -}}

--- a/modules/platen/layouts/partials/platen/markup/code_snippets/image.html
+++ b/modules/platen/layouts/partials/platen/markup/code_snippets/image.html
@@ -18,7 +18,7 @@
     key that is added from aliases when aliases is a slice or string instead
     of a map.
 */}}
-{{- $ConfigKey       := printf "platen.markup.%s" $MarkupName                     -}}
+{{- $ConfigKey       := printf "platen.markup.code_snippets"                      -}}
 {{- $Config          := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
 {{- $Aliases         := $Config.aliases                                           -}}
 {{- $DefaultPrefixes := "code"                                                    -}}

--- a/modules/platen/layouts/partials/platen/markup/details/_canonicalize.html
+++ b/modules/platen/layouts/partials/platen/markup/details/_canonicalize.html
@@ -1,4 +1,4 @@
-z{{- $Params     := .                  -}}
+{{- $Params     := .                  -}}
 {{- $Config     := $Params.Config     -}} {{/* The markup's site configuration, like platen.markup.foo     */}}
 {{- $Position   := $Params.Position   -}} {{/* The markup's position in the Markdown - only for codeblocks */}}
 {{- $Page       := $Params.Page       -}} {{/* The Page object for the Markdown document the markup is in  */}}
@@ -34,11 +34,12 @@ z{{- $Params     := .                  -}}
       returns them as a single space-delimited string, marked as safe for
       insertion into HTML attributes.
 */}}
-{{- $mungeHeadingLevel  := "platen/utils/mungeHeadingLevel"    -}}
-{{- $getLeadTrimmedText := "platen/utils/getLeadTrimmedText"   -}}
-{{- $getMergedClasses   := "platen/utils/getMergedClasses"     -}}
-{{- $getPrettyRender    := "platen/utils/getPrettyRender"      -}}
-{{- $getSafeAttributes  := "platen/utils/getSafeAttributes"    -}}
+{{- $mungeHeadingLevel  := "platen/utils/mungeHeadingLevel"                    -}}
+{{- $getLeadTrimmedText := "platen/utils/getLeadTrimmedText"                   -}}
+{{- $getMergedClasses   := "platen/utils/getMergedClasses"                     -}}
+{{- $getPrettyRender    := "platen/utils/getPrettyRender"                      -}}
+{{- $getSafeAttributes  := "platen/utils/getSafeAttributes"                    -}}
+{{- $resolveIconOptions := "platen/features/shoelace/utils/resolveIconOptions" -}}
 {{/*  Define the template folder and default template for this markup  */}}
 {{- $TemplateFolder := "platen/markup/details/templates" -}}
 {{- $template       := "default"                         -}}
@@ -164,6 +165,33 @@ z{{- $Params     := .                  -}}
   {{- $iconCollapse = "" -}}
   {{- $iconExpand   = "" -}}
 {{- else if $hasBothIcons -}}
+  {{/*  Need to validate the icon options for both icons and get their attribute lists  */}}
+  {{- $iconsMap := dict "icon_expand" $options.icon_expand "icon_collapse" $options.icon_collapse -}}
+  {{- range $For, $Icon := $iconsMap -}}
+    {{- $resolveIconParams  := dict "Page" $Page "Position" $Position "Icon" $Icon         -}}
+    {{- $iconAttributeMap   := partialCached $resolveIconOptions $resolveIconParams $Icon  -}}
+
+    {{- $iconAttributes := slice -}}
+    {{- range $Key, $Value := $iconAttributeMap -}}
+      {{- if ne "variant" $Key -}}
+        {{- $IconAttribute := printf `%s="%s"` $Key (print $Value)    -}}
+        {{- $iconAttributes = $iconAttributes | append $IconAttribute -}}
+      {{- end -}}
+    {{- else -}}
+      {{- warnf "Unable to validation icon for '%s': %+v - ignoring custom icons for details at %s"
+                $For
+                $Icon
+                $Position
+      -}}
+      {{- $hasBothIcons = false -}}
+    {{- end -}}
+
+    {{- $slot            := cond (eq "icon_expand" $For) "expand-icon" "collapse-icon" -}}
+    {{- $iconAttributes   = $iconAttributes | append (printf `slot="%s"` $slot)        -}}
+    {{- $attributeParams := dict "Attributes" $iconAttributes "IndentCount" 8          -}}
+    {{- $iconAttributes   = partial "platen/utils/getSafeAttributes" $attributeParams  -}}
+    {{- $options          = merge $options (dict $For $iconAttributes)                 -}}
+  {{- end -}}
   {{/*  Need to add .NoRotateIcon class for custom icons  */}}
   {{- with $options.class -}}
     {{- $options = merge $options (dict "class" (printf "no-rotate-icon %s" $options.class)) -}}
@@ -302,9 +330,9 @@ z{{- $Params     := .                  -}}
   {{/*  For shoelace, the summary is *always* rendered in a div with the slot defined  */}}
   {{- $summaryHtml = printf "<div %s>\n    %s\n  </div>" $summaryAttributes $summaryHtml -}}
   {{- if $hasBothIcons -}}
-    {{- $collapseHtml := printf `<sl-icon name="%s" slot="collapse-icon"></sl-icon>` $options.icon_collapse -}}
-    {{- $expandHtml   := printf `<sl-icon name="%s" slot="expand-icon"></sl-icon>`   $options.icon_expand   -}}
-    {{- $summaryHtml   = printf "%s\n  %s\n  %s" $expandHtml $collapseHtml $summaryHtml                     -}}
+    {{- $collapseHtml := printf "<sl-icon %s></sl-icon>" $options.icon_collapse         -}}
+    {{- $expandHtml   := printf "<sl-icon %s></sl-icon>" $options.icon_expand           -}}
+    {{- $summaryHtml   = printf "%s\n  %s\n  %s" $expandHtml $collapseHtml $summaryHtml -}}
   {{- end -}}
 
   {{/*  Add the summary HTML to the template context for use  */}}

--- a/modules/platen/layouts/partials/platen/menu/filetree.html
+++ b/modules/platen/layouts/partials/platen/menu/filetree.html
@@ -1,3 +1,21 @@
+{{/*
+    Partial: menu/filetree
+
+    This partial recursively renders nav list entries for the site menu from the
+    configured root section.
+
+    It only adds pages to the nav menu if they don't have `platen.menu.hide` 
+    set to `false in their front matter.
+
+    For section pages, it handles whether the section should be displayed in
+    the default format (children indented), as a flat section (section entry
+    bold, children not indented), or a collapsible section (click to expand or
+    collapse the section).
+
+    Every non-hidden page with content is added as a link in the nav menu. Leaf
+    pages without content are ignored. Section pages without content are added
+    but not linked.
+*/}}
 {{- $ConfigKey     := "platen.display.menu"                                     -}}
 {{- $MenuConfig    := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
 {{- $PlatenSection := $MenuConfig.root_section | default "/"                    -}}
@@ -29,13 +47,21 @@
 {{ end }}
 
 {{ define "platen-page-link" }}
-  {{- $EntryPage           := .                                                       -}}
-  {{- $HasContent          := $EntryPage.Content                                      -}}
-  {{- $IsCurrentPage       := eq page $EntryPage                                      -}}
-  {{- $IsAncestorPage      := $EntryPage.IsAncestor page                              -}}
-  {{- $IsAncestorOrCurrent := or $IsCurrentPage $IsAncestorPage                       -}}
-  {{- $TitleParams         := dict "Context" $EntryPage "ForMenu" true                -}}
-  {{- $TitleText           := partial "platen/utils/getTitle" $TitleParams            -}}
+  {{- $EntryPage           := .                                 -}}
+  {{- $HasContent          := $EntryPage.Content                -}}
+  {{- $IsCurrentPage       := eq page $EntryPage                -}}
+  {{- $IsAncestorPage      := $EntryPage.IsAncestor page        -}}
+  {{- $IsAncestorOrCurrent := or $IsCurrentPage $IsAncestorPage -}}
+  {{/*  Define partials for easier reuse/maintenance  */}}
+  {{- $getSafeAttributes  := "platen/utils/getSafeAttributes" -}}
+  {{- $getTitle           := "platen/utils/getTitle"          -}}
+  {{- $getDisplayTitle    := "platen/utils/getDisplayTitle"   -}}
+  {{/*  Get the title text  */}}
+  {{- $titleParams := dict "Context" $EntryPage "ForMenu" true  -}}
+  {{- $titleText   := partial $getTitle $titleParams            -}}
+  {{- $titleParams  = dict "Page" $EntryPage "Title" $titleText -}}
+  {{- $titleText    = partial $getDisplayTitle $titleParams     -}}
+  {{/*  Determine whether the link is for the active page active  */}}
   {{- $LinkClassAttribute  := cond $IsCurrentPage `class="active"` "" | safeHTMLAttr -}}
 
   {{ if $EntryPage.Params.platen.menu.collapse_section }}
@@ -50,14 +76,14 @@
           {{- else -}}
             role="button"
           {{- end }}>
-        {{- $TitleText -}}
+        {{- $titleText -}}
       </a>
     </label>
   {{ else if $HasContent }}
     <a {{ $LinkClassAttribute }} href="{{ $EntryPage.Permalink }}">
-      {{- $TitleText -}}
+      {{- $titleText -}}
     </a>
   {{ else }}
-    <span>{{- $TitleText -}}</span>
+    <span>{{- $titleText -}}</span>
   {{ end }}
 {{ end }}

--- a/modules/platen/layouts/partials/platen/menu/languages.html
+++ b/modules/platen/layouts/partials/platen/menu/languages.html
@@ -1,17 +1,71 @@
+{{/*
+    Partial: menu/languages
+
+    This partial handles rendering the translated pages for links in the site
+    menu when the site is multilingual.
+
+    It expects no input and always processes the current page. It only expects
+    to be called when the site is multilingual.
+
+    It renders a list where the first item in the list is a dropdown toggle.
+    The dropdown toggle's label has a prefix icon defined by the configuration
+    setting platen.display.menu.languages_icon. The label text is the language
+    of the currently displayed page.
+
+    When the dropdown is toggled open, it displays the list of translations for
+    the current page. Each item is a link to the translation with the link text
+    set to the name of the language.
+*/}}
+{{/*  Define partials for easier reuse/naming  */}}
+{{- $getKey            := "platen/param/getKey"            -}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+{{/*  Get language settings  */}}
 {{- $ConfigKey     := "platen.multilingual"                                     -}}
 {{- $LangConfig    := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
-<!-- Merge home and current page translations -->
+
+{{/*  Merge home and current page translations  */}}
 {{- $TranslatedOnly := $LangConfig.translated_only | default false -}}
 {{- $translations   := dict                                        -}}
-
 {{- if (eq $TranslatedOnly false) -}}
   {{- range $Translation := site.Home.Translations -}}
     {{- $translations = merge $translations (dict $Translation.Language.Lang $Translation) -}}
   {{- end -}}
 {{- end -}}
-
 {{- range $Translation := page.Translations -}}
   {{- $translations = merge $translations (dict $Translation.Language.Lang $Translation) -}}
+{{- end -}}
+
+{{/*  Pre-define the language template and icon information.  */}}
+{{- $template        := "platen/features/shoelace/templates/icon"           -}}
+{{- $templateParams  := dict                                                -}}
+{{- $IconConfigKey   := "platen.display.menu.languages_icon"                -}}
+{{- $IconConfig      := partialCached $getKey $IconConfigKey $IconConfigKey -}}
+
+{{- if $IconConfig.use_legacy -}}
+  {{- $template = "platen/menu/languages/legacy" -}}
+{{- else -}}
+  {{/*  Make sure the custom-handled options aren't sent as attributes  */}}
+  {{- $SkipOptions := slice "use_legacy" "classes" -}}
+  
+  {{/*  Initialize the attribute list with the href  */}}
+  {{- $options := dict -}}
+
+  {{/*  Handle the button's classes  */}}
+  {{- $classes := slice "platen-icon" -}}
+  {{- with $IconConfig.classes -}}
+    {{- $classes = union $classes $IconConfig.classes -}}
+  {{- end -}}
+  {{- $classes = delimit $classes " "                   -}}
+  {{- $options = merge $options (dict "class" $classes) -}}
+
+  {{/*  Handle remaining options  */}}
+  {{- range $Name, $Value := $IconConfig -}}
+    {{- if not (in $SkipOptions $Name) -}}
+      {{- $options = merge $options (dict $Name $Value) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $templateParams = dict "Page" page "Icon" $options -}}
 {{- end -}}
 
 <ul class="platen-languages">
@@ -19,7 +73,7 @@
     <input type="checkbox" id="languages" class="toggle" />
     <label for="languages" class="flex justify-between">
       <a role="button" class="flex align-center">
-        <img src="{{ "svg/translate.svg" | relURL }}" class="platen-icon" alt="Languages" />
+        {{ partial $template $templateParams }}
         {{ site.Language.LanguageName }}
       </a>
     </label>
@@ -38,3 +92,11 @@
     </ul>
   </li>
 </ul>
+
+{{- define "partials/platen/menu/languages/legacy" -}}
+  {{- $Src := "svg/translate.svg" | relURL | safeHTMLAttr -}}
+  <a role="button" class="flex align-center">
+    <img src="{{ $Src }}" class="platen-icon" alt="Languages" />
+    {{ site.Language.LanguageName }}
+  </a>
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/param/_resolve.html
+++ b/modules/platen/layouts/partials/platen/param/_resolve.html
@@ -1,27 +1,59 @@
 {{/*
-    This partial is used to canonically resolve a configuration option by merging the configuration
-    setting from data, Hugo's configuration (files and environment), a page's front matter, and a
-    default value.
+    Param Partial: _resolve
+    
+    This private partial is used to canonically resolve a configuration option
+    by merging the configuration setting from data, Hugo's configuration (files
+    and environment), a page's front matter, and a default value.
 
-    When only a ConfigKey is provided, the value is a deep merge of the key's data over
-    configuration.
+    When only one key is provided for Config, the value is a deep merge of the
+    key's data over configuration. When more than one key is provided for
+    Config, the first key that resolves is used.
 
-    When only a ParamKey is provided, the value is pulled from the page's front matter. To use this
-    option, the caller must pass the page's context.
+    When only one key is provided for Param, the value is pulled from the
+    page's front matter. To use this option, the caller must pass the page's
+    context. If the page's context isn't provided, the partial will try to use
+    the current page context, if available. When more than one key is provided
+    for Param, the first key that resolves is used.
 
-    When a ConfigKey and ParamKey are provided, the value from the page's front matter is used if
-    it's available. If it isn't, the value defaults to the deep merge of the key's data over
-    configuration.
+    When keys for both Config and Param are provided, the value from the page's
+    front matter is used if it's available. If it isn't, the value defaults to
+    the deep merge of the key's data over configuration. In all cases, only the
+    first resolved value is used.
 
-    When a Default is provided, the value is set to the Default only if the value would otherwise
-    be nil.
+    When a Default is provided, the value is set to the Default only if the
+    value would otherwise be nil.
+
+    For example, consider this input:
+
+        dict "Config" (slice "display.foo.bar" "display.foo_bar")
+             "Param"  (slice "foo.bar" "foo_bar")
+             Context  page
+             Default  false
+    
+    In this case, the values resolve in the following order, returning the
+    first value from this list that does resolve to a value.
+
+    - foo.bar in the page front matter
+    - foo_bar in the page front matter
+    - display.foo.bar in the site config
+    - display.foo_bar in the site config
+    - false
+
+    The default value false is only returned if all other lookups fail to
+    resolve to a value.
 */}}
-{{- $Input       := .              -}}
-{{- $Context     := $Input.Context -}}
-{{- $ConfigKey   := $Input.Config  -}}
-{{- $ParamKey    := $Input.Param   -}}
-{{- $value       := ""             -}}
+{{- $Input       := .                              -}}
+{{- $Context     := $Input.Context | default page  -}}
+{{- $InputConfig := $Input.Config  | default slice -}}
+{{- $InputParam  := $Input.Param   | default slice -}}
+{{/*  Define partials for easier renaming/maintenance  */}}
+{{- $getKey       := "platen/param/getKey"       -}}
+{{- $getPageParam := "platen/param/getPageParam" -}}
+{{/*  Define a constant for when the value hasn't been resolved yet  */}}
+{{- $UndefinedValue := "!UNDEFINED!"    -}}
+{{- $value          := $UndefinedValue  -}}
 
+{{/*  Error if the input is invalid  */}}
 {{- if not (reflect.IsMap $Input) -}}
   {{- errorf "%s: %s Was: %#v"
              "Invalid input for 'utils/config/resolve'"
@@ -30,34 +62,69 @@
   -}}
 {{- end -}}
 
-{{- $resolving := dict "Config" $ConfigKey "Param" $ParamKey "Default" $Input.Default -}}
+{{/*  We always want to process slices of keys, so munge a non-slice into a slice.  */}}
+{{- $ParamKeys  := cond (reflect.IsSlice $InputParam)  $InputParam  (slice $InputParam)  -}}
+{{- $ConfigKeys := cond (reflect.IsSlice $InputConfig) $InputConfig (slice $InputConfig) -}}
 
-{{- with $ConfigKey -}}
-  {{- $configValue := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
-  {{- with $ParamKey -}}
-    {{- $paramValue := $Context.Params -}}
-    {{- range $segment := split $ParamKey "." -}}
-      {{- $paramValue = index $paramValue $segment -}}
+{{/*  Set the Resolving info for use in messaging/debugging  */}}
+{{- $Resolving := dict "Config" $ConfigKeys "Param" $ParamKeys "Default" $Input.Default -}}
+
+{{- range $ConfigKey := $ConfigKeys -}}
+  {{/*  Only process the config key if no value has been set yet.  */}}
+  {{- if eq $value $UndefinedValue -}}
+    {{- $ConfigLookup := dict "Key" $ConfigKey "WithValidity" true         -}}
+    {{- $ConfigInfo   := partialCached $getKey $ConfigLookup $ConfigLookup -}}
+
+    {{/*  Check each defined page param key, using the first defined one, if any  */}}
+    {{- range $ParamKey := $ParamKeys -}}
+      {{- if eq $value $UndefinedValue -}}
+        {{- $ParamLookup := dict "Page" $Context "Key" $ParamKey "WithValidity" true "Resolving" $Resolving -}}
+        {{- $ParamInfo   := partialCached  $getPageParam $ParamLookup $ParamLookup (md5 $Context) -}}
+
+        {{- if eq true $ParamInfo.Valid -}}
+          {{- $value = $ParamInfo.Value -}}
+        {{- end -}}
+      {{- end -}}
     {{- end -}}
-    {{- $value = $paramValue | default $configValue -}}
+
+    {{/*  If no page param resolved, use the config key value if available  */}}
+    {{- if and (eq true $ConfigInfo.Valid) (eq $value $UndefinedValue) -}}
+      {{- $value = $ConfigInfo.Value -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
-  {{- with $ParamKey -}}
-    {{- $value = $Context.Params -}}
-    {{- range $segment := split $ParamKey "." -}}
-      {{- $value = index $value $segment -}}
+  {{/*  Without any config keys defined, loop over the param keys  */}}
+  {{- range $ParamKey := $ParamKeys -}}
+    {{/*  Only process the param key if no value has been set yet  */}}
+    {{- if eq $value $UndefinedValue -}}
+      {{- $LookupParams := dict "Page" $Context "Key" $ParamKey "WithValidity" true                -}}
+      {{- $ParamInfo    := partialCached  $getPageParam $LookupParams $LookupParams (md5 $Context) -}}
+      
+      {{- if eq true $ParamInfo.Valid -}}
+        {{- $value = $ParamInfo.Value -}}
+      {{- end -}}
     {{- end -}}
   {{- else -}}
+    {{/*  If no config keys were specified and no param keys were specified, error.  */}}
     {{- errorf "%s: %s Was: %#v"
                "Invalid input for 'utils/config/resolve'"
-               "Must be a map with 'Config' and/or 'Param' or a string (implicitly 'Config')."
+               "Must be a map with 'Config' and/or 'Param' defined."
                $Input
     -}}
   {{- end -}}
 {{- end -}}
 
-{{- if isset $Input "Default" -}}
-  {{- $value = $value | default $Input.Default -}}
+{{/*  If no config keys or param keys resolved, set the default value or warn if no default.  */}}
+{{- if eq $value $UndefinedValue -}}
+  {{- if and (isset $Input "Default") -}}
+    {{- $value = $Input.Default -}}
+  {{- else -}}
+    {{- warnf "%s; %s. Resolving parameters were: %s"
+              "Unable to resolve param lookup"
+              "no value found for any key and no default specified"
+              ($Resolving | jsonify (dict "indent" "  "))
+    -}}
+  {{- end -}}
 {{- end -}}
 
 {{- return $value -}}

--- a/modules/platen/layouts/partials/platen/param/checkShortcodes.html
+++ b/modules/platen/layouts/partials/platen/param/checkShortcodes.html
@@ -1,27 +1,42 @@
-{{/* Retrieve the registered shortcodes, process the disabled ones */}}
+{{/*
+    Param Partial: checkShortcodes
+
+    This partial is used to inspect the shortcodes used on a page, raising an
+    error if any of the shortcodes are disabled. It doesn't warn or error for
+    unrecognized shortcodes.
+*/}}
+
+{{/* Retrieve the disabled registered shortcodes, process the disabled ones */}}
 {{- $Params     := dict "DisabledOnly" true                                             -}}
 {{- $Shortcodes := partialCached "platen/param/getRegisteredShortcodes" $Params "check" -}}
 
 {{- range $Shortcode, $Settings := $Shortcodes -}}
+  {{/*  Get the list of valid shortcode names for this disabled shortcode  */}}
   {{- $names := slice $Shortcode -}}
   {{- with $Settings.aliases -}}
     {{- $names = union $names $Settings.aliases -}}
   {{- end -}}
   
+  {{/*  The prefix finds the opening of a shortcode, like {{< or {{%  */}}
   {{- $Prefix  := "[^`]?{{(<|%)"                                     -}}
+  {{/*  The pattern finds any shortcodes in a block of text with this disabled shortcode's name  */}}
   {{- $Pattern := printf `%s\s+(%s)\s+` $Prefix (delimit $names "|") -}}
   {{- $Usages  := findRE $Pattern page.RawContent                    -}}
+
+  {{/*  Error if the content includes any disabled shortcodes.  */}}
   {{- if gt (len $Usages) 0 -}}
     {{- $message := slice    (printf "Found usage of the disabled '%s'"         $Shortcode)
                     | append (printf "shortcode in content for '%s'."           page.File.Path)
                     | append (printf "Set platen.shortcodes.%s.enabled to true" $Shortcode)
                     | append "in your site configuration or remove all uses of the shortcode."
     -}}
+
     {{- with $Settings.aliases -}}
       {{- $Aliases := delimit $Settings.aliases "', '" "', and '"                 -}}
       {{- $Suffix  := printf "Aliases for this shortcode include: '%s'." $Aliases -}}
       {{- $message  = $message | append $Suffix                                   -}}
     {{- end -}}
+
     {{- errorf "%s" (delimit $message " ") -}}
   {{- end -}}
 {{- end -}}

--- a/modules/platen/layouts/partials/platen/param/classes/_getList.html
+++ b/modules/platen/layouts/partials/platen/param/classes/_getList.html
@@ -1,7 +1,28 @@
-{{- $Context     := .                                                         -}}
-{{- $PageUrl     := $Context.RelPermalink                                     -}}
-{{- $ConfigKey   := "platen.display.section_classes"                          -}}
-{{- $ClassConfig := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
+{{/*
+    Platen Param Partial: classes/_getList
+
+    This partial compares the site configuration for section classes and a
+    page's front matter for extra classes, building a list of classes to inject
+    for the page.
+
+    This partial expects to receive a page's context as input.
+
+    It first looks up the "platen.display.section_classes" configuration. If
+    that configuration is defined and has an entry for this page or one of its
+    parent sections, the class list is added to the page's class list.
+
+    Next, it checks the front matter for the page. If platen.extra_classes is
+    defined, those classes are added to the list.
+
+    Finally, the partial returns the full list of classes to inject for the
+    page.
+*/}}
+{{- $getKey := "platen/param/getKey" -}}
+
+{{- $Context     := .                                                            -}}
+{{- $PageUrl     := $Context.RelPermalink                                        -}}
+{{- $ConfigKey   := "platen.display.section_classes"                             -}}
+{{- $ClassConfig := partialCached $getKey $ConfigKey $ConfigKey | default (dict) -}}
 
 {{- $classList := slice -}}
 

--- a/modules/platen/layouts/partials/platen/param/classes/canonicalize.html
+++ b/modules/platen/layouts/partials/platen/param/classes/canonicalize.html
@@ -1,3 +1,16 @@
+{{/*
+    Platen Param Partial: classes/canonicalize
+
+    This partial inspects a page to find the list of CSS classes to inject into
+    its body element and stores them in the page's store (a persistent scratch)
+    as an HTML class attribute under the PlatenBodyClassAttribute key.
+
+    If this partial doesn't receive a specific page's context as input, it
+    tries to use the current page as the default.
+
+    It only sets the PlatenBodyClassAttribute in the page's store if the
+    resolved class list isn't empty.
+*/}}
 {{- $Context := . | default page -}}
 
 {{- $classList := partial "platen/param/classes/_getList" $Context -}}

--- a/modules/platen/layouts/partials/platen/param/getKey.html
+++ b/modules/platen/layouts/partials/platen/param/getKey.html
@@ -1,14 +1,67 @@
 {{/*
-    This partial is used to retrieve the canonicalized value of a site configuration parameter by
-    merging the configuration setting from data over Hugo's configuration (files and environment).
+    Param Partial: getKey
+
+    This partial is used to retrieve the canonicalized value of a site
+    configuration parameter by merging the configuration setting from data over
+    Hugo's configuration (files and environment).
+
+    It expects either the input to be either:
+
+    1. A string representing the dot-path key to lookup
+    2. A dictionary with the key-value pairs:
+
+       - Key: (Mandatory) A string representing the dot-path key to lookup.
+       - WithValidity: (Optional, default false) A boolean for whether the
+         partial should return the validity status of the lookup with the value.
+    
+    If the input is a string or the WithValidity parameter is false, the
+    partial returns the lookup value only, defaulting to an empty string if it
+    couldn't be resolved.
+
+    If the input is a dictionary and WithValidity is true, the partial returns
+    a dictionary with the following keys:
+
+    - Value: The resolved value of the lookup. If the lookup failed, this value
+      is an empty string.
+    - Valid: A boolean value representing whether the lookup succeeded. If the
+      lookup failed (the key wasn't set at all), this key is false. This can
+      help the caller distinguish between keys that were explicitly set to an
+      empty or null value and those where the lookup failed.
 */}}
-{{- $Key := . -}}
-
-{{- $Config := partialCached "platen/param/getMergedValue" (dict) "full" -}}
-
-{{- $value := $Config -}}
-{{- range $Segment := split $Key "." -}}
-  {{- $value = index $value $Segment -}}
+{{- $Input        := .     -}}
+{{- $key          := .     -}}
+{{- $withValidity := false -}}
+{{- if reflect.IsMap $Input -}}
+  {{- $key          = $Input.Key                          -}}
+  {{- $withValidity = $Input.WithValidity | default false -}}
 {{- end -}}
 
-{{- return $value -}}
+{{/*  Retrieve the merged site configuration  */}}
+{{- $Config := partialCached "platen/param/getMergedValue" (dict) "full" -}}
+
+{{/*  Initialize the value and validity  */}}
+{{- $value := $Config -}}
+{{- $valid := true    -}}
+
+{{/*
+    Split the dot-path key and index into each segment, setting the value if
+    it's defined. If it isn't defined, set the value to an empty string and
+    mark the lookup as invalid.
+*/}}
+{{- range $Segment := split $key "." -}}
+  {{- if $valid -}}
+    {{- if (isset $value $Segment) -}}
+      {{- $value = index $value $Segment -}}
+    {{- else -}}
+      {{- $valid = false -}}
+      {{- $value = ""    -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $Output := cond (eq true $withValidity)
+               (dict "Value" $value "Valid" $valid)
+               $value
+-}}
+
+{{- return $Output -}}

--- a/modules/platen/layouts/partials/platen/param/getMergedValue.html
+++ b/modules/platen/layouts/partials/platen/param/getMergedValue.html
@@ -1,16 +1,19 @@
 {{/*
-    This partial is used to retrieve the canonicalized value of the site's configuration params by
-    merging the settings from data over Hugo's configuration (files and environment).
+    This partial is used to retrieve the canonicalized value of the site's
+    configuration params by merging the settings from data over Hugo's
+    configuration (files and environment).
 
-    We use `isset` instead of the more convenient `with` because values can be explicitly set to a
-    falsy value. Hugo treats all of the following as false values in a `with` statement:
+    We use `isset` instead of the more convenient `with` because values can be
+    explicitly set to a falsy value. Hugo treats all of the following as false
+    values in a `with` statement:
 
     - Boolean `false`
     - Integer `0`
     - Any zero-length array, slice, map, or string.
 
-    Normally, this is desired, but because you can explicitly define empty/null/false settings and
-    they ought to _override_ defined settings, we need to handle them.
+    Normally, this is desired, but because you can explicitly define
+    empty/null/false settings and they ought to _override_ defined settings,
+    we need to handle them.
 */}}
 {{- $Context := .                                           -}}
 {{- $Data    := $Context.Data   | default site.Data._params -}}

--- a/modules/platen/layouts/partials/platen/param/getPageParam.html
+++ b/modules/platen/layouts/partials/platen/param/getPageParam.html
@@ -1,0 +1,57 @@
+{{/*
+    Param Partial: getPageParam
+
+    This partial is used to retrieve a parameter from a page's front matter,
+    using a dot-path key to index into values nested in a dictionary.
+
+    It expects either the input to be a dictionary with the following keys:
+
+    - Page: (Mandatory) The page whose front matter to index for the Key.
+    - Key: (Mandatory) A string representing the dot-path key to lookup.
+    - WithValidity: (Optional, default false) A boolean for whether the
+      partial should return the validity status of the lookup with the value.
+    
+    If WithValidity is false, the partial returns the lookup value only,
+    defaulting to an empty string if it couldn't be resolved.
+
+    If WithValidity is true, the partial returns a dictionary with the
+    following keys:
+
+    - Value: The resolved value of the lookup. If the lookup failed, this value
+      is an empty string.
+    - Valid: A boolean value representing whether the lookup succeeded. If the
+      lookup failed (the key wasn't set at all), this key is false. This can
+      help the caller distinguish between keys that were explicitly set to an
+      empty or null value and those where the lookup failed.
+*/}}
+{{- $Params       := .                                    -}}
+{{- $Page         := $Params.Page                         -}}
+{{- $Key          := $Params.Key                          -}}
+{{- $WithValidity := $Params.WithValidity | default false -}}
+
+{{/*  Initialize the value and validity  */}}
+{{- $value := $Page.Params -}}
+{{- $valid := true         -}}
+
+{{/*
+    Split the dot-path key and index into each segment, setting the value if
+    it's defined. If it isn't defined, set the value to an empty string and
+    mark the lookup as invalid.
+*/}}
+{{- range $Segment := split $Key "." -}}
+  {{- if $valid -}}
+    {{- if (isset $value $Segment) -}}
+      {{- $value = index $value $Segment -}}
+    {{- else -}}
+      {{- $valid = false -}}
+      {{- $value = ""    -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $Output := cond (eq true $WithValidity)
+               (dict "Value" $value "Valid" $valid)
+               $value
+-}}
+
+{{- return $Output -}}

--- a/modules/platen/layouts/partials/platen/param/getRegisteredShortcodes.html
+++ b/modules/platen/layouts/partials/platen/param/getRegisteredShortcodes.html
@@ -1,19 +1,31 @@
 {{/*
-    This partial is used to retrieve the list of all registered shortcodes, optionally on returning
-    the disabled ones.
+    Param Partial: getRegisteredShortcodes
+
+    This partial is used to retrieve the list of all registered shortcodes,
+    optionally only returning the disabled ones. The shortcodes are returned as
+    a dictionary where the key is the shortcode name and the value is the
+    shortcode's configuration.
+
+    If DisabledOnly is passed as `true`, the partial inspects all registered
+    shortcodes and discards any shortcodes whose `enabled` settting key is
+    set to `true`.
 */}}
 {{- $Params       := .                                    -}}
 {{- $DisabledOnly := $Params.DisabledOnly | default false -}}
 
-{{- $registeredShortcodes := partialCached "platen/param/getKey" "platen.shortcodes" "platen.shortcodes" -}}
+{{- $getKey               := "platen/param/getKey"                       -}}
+{{- $ConfigKey            := "platen.shortcodes"                         -}}
+{{- $registeredShortcodes := partialCached $getKey $ConfigKey $ConfigKey -}}
 
 {{- if $DisabledOnly -}}
   {{- $disabledShortcodes := dict -}}
+
   {{- range $Shortcode, $Settings := $registeredShortcodes -}}
     {{- if eq $Settings.enabled false -}}
       {{- $disabledShortcodes = merge $disabledShortcodes (dict $Shortcode $Settings) -}}
     {{- end -}}
   {{- end -}}
+
   {{- $registeredShortcodes = $disabledShortcodes -}}
 {{- end -}}
 

--- a/modules/platen/layouts/partials/platen/param/resolve.html
+++ b/modules/platen/layouts/partials/platen/param/resolve.html
@@ -1,25 +1,50 @@
 {{/*
-    This partial is a convenience partial to wrap calling `_resolve` and caching the results without
-    requiring the called to use a very long call. Without this partial, caching a resolution would
-    look like line 14 everywhere it's used, making for very long lines and continually repeated
+    This partial is a convenience partial to wrap calling `_resolve` and
+    caching the results without requiring the caller to use a very long call.
+    Without this partial, caching a resolution would look like line 57
+    everywhere it's used, making for very long lines and continually repeated
     boilerplate.
 
-    `_resolve` is used to canonically resolve a configuration option by merging the configuration
-    setting from data, Hugo's configuration (files and environment), a page's front matter, and a
-    default value.
+    `_resolve` is used to canonically resolve a configuration option by merging
+    the configuration setting from data, Hugo's configuration (files and
+    environment), a page's front matter, and a default value.
 
-    When only a ConfigKey is provided, the value is a deep merge of the key's data over
-    configuration.
+    When only one key is provided for Config, the value is a deep merge of the
+    key's data over configuration. When more than one key is provided for
+    Config, the first key that resolves is used.
 
-    When only a ParamKey is provided, the value is pulled from the page's front matter. To use this
-    option, the caller must pass the page's context.
+    When only one key is provided for Param, the value is pulled from the
+    page's front matter. To use this option, the caller must pass the page's
+    context. If the page's context isn't provided, the partial will try to use
+    the current page context, if available. When more than one key is provided
+    for Param, the first key that resolves is used.
 
-    When a ConfigKey and ParamKey are provided, the value from the page's front matter is used if
-    it's available. If it isn't, the value defaults to the deep merge of the key's data over
-    configuration.
+    When keys for both Config and Param are provided, the value from the page's
+    front matter is used if it's available. If it isn't, the value defaults to
+    the deep merge of the key's data over configuration. In all cases, only the
+    first resolved value is used.
 
-    When a Default is provided, the value is set to the Default only if the value would otherwise
-    be nil.
+    When a Default is provided, the value is set to the Default only if the
+    value would otherwise be nil.
+
+    For example, consider this input:
+
+        dict "Config" (slice "display.foo.bar" "display.foo_bar")
+             "Param"  (slice "foo.bar" "foo_bar")
+             Context  page
+             Default  false
+    
+    In this case, the values resolve in the following order, returning the
+    first value from this list that does resolve to a value.
+
+    - foo.bar in the page front matter
+    - foo_bar in the page front matter
+    - display.foo.bar in the site config
+    - display.foo_bar in the site config
+    - false
+
+    The default value false is only returned if all other lookups fail to
+    resolve to a value.
 */}}
 {{- $Input       := .                       -}}
 {{- $Context     := $Input.Context          -}}

--- a/modules/platen/layouts/partials/platen/param/validate/legacy.html
+++ b/modules/platen/layouts/partials/platen/param/validate/legacy.html
@@ -1,0 +1,44 @@
+{{- $deepIndex := "platen/utils/deepIndex" -}}
+{{- $resolve   := "platen/param/resolve"   -}}
+
+{{- $SettingsToCheck := slice
+      "display.table_of_contents.use_legacy"
+      "display.menu.languages_icon.use_legacy"
+      "display.mobile.menu_control.use_legacy"
+      "display.mobile.toc_control.use_legacy"
+      "display.footer.last_edited_on.use_legacy"
+      "display.footer.edit_this_page.use_legacy"
+-}}
+
+{{- $legacySettings := slice -}}
+{{- range $SettingKey := $SettingsToCheck -}}
+  {{- $Indexing := dict "Config" (printf "platen.%s" $SettingKey) -}}
+  {{- $Setting  := partial $resolve $Indexing                     -}}
+  {{- if eq true $Setting -}}
+    {{- $legacySettings = $legacySettings | append $SettingKey -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with $legacySettings -}}
+  {{- $legacySettings = delimit $legacySettings "\n\t" -}}
+  {{- $Message       := delimit (
+        slice
+        "You're using legacy settings!"
+        ""
+        "Platen has begun to migrate to fully incorporating Shoelace for"
+        "various theme components and markup options. While the legacy"
+        "options are still functional, they're deprecated. You should begin"
+        "to migrate your settings and theme to use the new functionality."
+        ""
+        "In the future, this warning will be an error. After that, the legacy"
+        "options will be removed from Platen entirely. Update the following"
+        "settings in your site configuration, setting each of these values to"
+        "false instead of true:"
+        ""
+        (printf "\t%s" $legacySettings)
+        ""
+        "For more information, see: https://platen.io/using/legacy"
+      ) "\n" | print
+  -}}
+  {{- warnf $Message -}}
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/post/listEntry.html
+++ b/modules/platen/layouts/partials/platen/post/listEntry.html
@@ -1,27 +1,42 @@
 {{/*
-    Docs.Partial: post/listEntry
+    Partial: post/listEntry
+
+    This partial is called for rendering blog post summaries in the blog
+    section's list page.
+
+    It expects a blog post's page context as input.
+
+    It renders an <article> element for the post with the post's title as a
+    link to the post. Under the title, it renders the blog post's metadata
+    information, which includes the publish date, tags, and categories.
+
+    Finally, it renders a summary for the blog post.
 */}}
 {{- $PostContext := . -}}
 
-{{- $Href        := $PostContext.RelPermalink                    -}}
-{{- $TitleParams := dict "Context" $PostContext "ForList" true   -}}
-{{- $Title       := partial "platen/utils/getTitle" $TitleParams -}}
-{{- $summary     := $PostContext.Summary                         -}}
-{{- $IsTruncated := $PostContext.Truncated                       -}}
+{{/*  Define the partials for easier renaming/maintenance  */}}
+{{- $resolve           := "platen/param/resolve"           -}}
+{{- $postsMeta         := "platen/utils/posts/meta"        -}}
+{{- $getDisplayTitle   := "platen/utils/getDisplayTitle"   -}}
+{{- $getTitle          := "platen/utils/getTitle"          -}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+
+{{- $Href        := $PostContext.RelPermalink                   -}}
+{{- $titleParams := dict "Context" $PostContext "ForList" true  -}}
+{{- $titleText   := partial $getTitle $titleParams              -}}
+{{- $titleParams  = dict "Page" $PostContext "Title" $titleText -}}
+{{- $titleText    = partial $getDisplayTitle $titleParams       -}}
+{{- $summary     := $PostContext.Summary                        -}}
+{{- $IsTruncated := $PostContext.Truncated                      -}}
 
 {{/* Define attribute list for article */}}
-{{- $articleAttributes := slice -}}
-{{- $articleAttributes  = $articleAttributes 
-                          | append `class="markdown platen-post"`
--}}
-{{- $articleAttributes  = partial "platen/utils/getSafeAttributes"
-                                  $articleAttributes
--}}
+{{- $articleAttributes := slice `class="markdown platen-post"`          -}}
+{{- $articleAttributes  = partial $getSafeAttributes $articleAttributes -}}
 
 {{/* Define attribute list for link */}}
-{{- $aAttributes := slice                                                 -}}
-{{- $aAttributes  = $aAttributes | append (printf `href="%s"` $Href)      -}}
-{{- $aAttributes  = partial "platen/utils/getSafeAttributes" $aAttributes -}}
+{{- $aAttributes := slice                                            -}}
+{{- $aAttributes  = $aAttributes | append (printf `href="%s"` $Href) -}}
+{{- $aAttributes  = partial $getSafeAttributes $aAttributes          -}}
 
 {{/* Add the truncated suffix if needed*/}}
 {{- if $IsTruncated -}}
@@ -29,11 +44,11 @@
 {{- end -}}
 
 {{/* Define the metadata elements */}}
-{{- $Meta := partial "platen/utils/posts/meta" $PostContext | safeHTML -}}
+{{- $Meta := partial $postsMeta $PostContext | safeHTML -}}
 
 {{/* Render */}}
 <article {{ $articleAttributes }}>
-  <h2><a {{ $aAttributes }}>{{ $Title }}</a></h2>
+  <h2><a {{ $aAttributes }}>{{ $titleText }}</a></h2>
   {{ $Meta }}
   <p>{{ $summary }}</p>
 </article>

--- a/modules/platen/layouts/partials/platen/post/title.html
+++ b/modules/platen/layouts/partials/platen/post/title.html
@@ -1,27 +1,42 @@
 {{/*
-  Docs.Partial: title
-*/}}
-{{- $Context := . -}}
+  Partial: post/title
 
+  This partial handles retrieving the title for a blog post's heading.
+
+  It resolves whether Platen has already rendered the heading for the blog post
+  due to the site configuration or page's front matter. If Platen hasn't 
+  already added a heading for the post, this partial handles adding the
+  heading.
+
+  This is required to prevent accidentally rendering the title as an h1 twice.
+*/}}
+
+{{/*  Define the partials for easier renaming/maintenance  */}}
+{{- $resolve           := "platen/param/resolve"           -}}
+{{- $getDisplayTitle   := "platen/utils/getDisplayTitle"   -}}
+{{- $getTitle          := "platen/utils/getTitle"          -}}
+{{- $getSafeAttributes := "platen/utils/getSafeAttributes" -}}
+{{/*  Define the lookup keys for easier renaming/maintenance  */}}
+{{- $ConfigKey      := "platen.display.header.title_as_heading" -}}
+{{- $ParamKey       := "platen.display_title.as_heading"        -}}
+{{- $LegacyParamKey := "platen.title_as_heading"                -}}
 {{/* Determine whether the page already has an h1 */}}
-{{- $HasHeading := partial "platen/param/resolve" (
-  dict "Config"  "platen.display.header.title_as_heading"
-       "Param"   "platen.title_as_heading"
-       "Context" $Context
-       "Default" false
-) -}}
+{{- $HasHeading := partial $resolve (
+      dict "Config"  $ConfigKey
+           "Param"   (slice $ParamKey $LegacyParamKey)
+           "Context" page
+           "Default" false
+    )
+-}}
 
 {{/* Continue only if the post doesn't already have a title heading */}}
 {{- if not $HasHeading -}}
-  {{- $TitleParams := dict "Context" $Context "ForHeading" true    -}}
-  {{- $TitleText   := partial "platen/utils/getTitle" $TitleParams -}}
-  {{- $Href        := $Context.RelPermalink                        -}}
-
-  {{/* Define the attribute list for the link */}}
-  {{- $attributes := slice                                                -}}
-  {{- $attributes  = $attributes | append (printf `href="%s"` $Href)      -}}
-  {{- $attributes  = partial "platen/utils/getSafeAttributes" $attributes -}}
+  {{- $titleParams := dict "Context" page "ForHeading" true  -}}
+  {{- $titleText   := partial $getTitle $titleParams         -}}
+  {{- $titleParams  = dict "Page" page "Title" $titleText    -}}
+  {{- $titleText    = partial $getDisplayTitle $titleParams  -}}
+  {{- $Href        := page.RelPermalink | safeURL            -}}
 
   {{/* Render the heading */}}
-  <h1><a {{ $attributes }}>{{ $TitleText }}</a></h1>
+  <h1><a href="{{ $Href}}">{{ $titleText }}</a></h1>
 {{- end -}}

--- a/modules/platen/layouts/partials/platen/toc.html
+++ b/modules/platen/layouts/partials/platen/toc.html
@@ -1,3 +1,5 @@
+{{- $Params  := .               -}}
+
 {{/*
   Determine whether to use Hugo's generator for the table of contents or Platen's. By default, use
   Platen's generator. If the site configuration specifies a value, use that setting.
@@ -11,12 +13,12 @@
        "Default" false
 ) -}}
 
-{{ partial "platen/inject/toc-before" }}
+{{ partial "platen/inject/toc-before" $Params }}
 
 {{ if $useBuiltInToC -}}
   {{ page.TableOfContents }}
 {{ else -}}
-  {{ partial "platen/toc/generate" }}
+  {{ partial "platen/toc/generate" $Params }}
 {{ end }}
 
-{{ partial "platen/inject/toc-after" }}
+{{ partial "platen/inject/toc-after" $Params }}

--- a/modules/platen/layouts/partials/platen/toc/_canonicalize.html
+++ b/modules/platen/layouts/partials/platen/toc/_canonicalize.html
@@ -1,0 +1,130 @@
+{{/*
+    TOC Partial: _canonicalize
+
+    This private partial canonicalizes the info for generating the TOC for a
+    list of headings on a page.
+
+    It expects no input and always operates on the current page.
+
+    The partial uses the merged settings for `platen.display.table_of_contents`
+    in the site configuration and `platen.table_of_contents` in the page's
+    front matter.
+
+    It searches for headings on the page that have a level in the valid range
+    (as defined by the `minimum_level` and `maximum_level` settings). It finds,
+    parses, and then canonicalizes the list of headings so that child headings
+    are associated with their parent heading.
+
+    The partial has handling for both the legacy template and the default
+    template, building the parameter map to send to it.
+
+    The partial returns a map that includes the template to call and the
+    parameters for that template.
+*/}}
+{{/*  Define partials for easier calling/renaming  */}}
+{{- $getKey               := "platen/param/getKey"                    -}}
+{{- $getMergedMap         := "platen/utils/getMergedMap"              -}}
+{{- $parseHeading         := "platen/toc/utils/parseHeading"          -}}
+{{- $canonicalizeHeadings := "platen/toc/utils/canonicalize/headings" -}}
+{{/*  Retrieve content and configuration  */}}
+{{- $PageContent   := page.Content                                              -}}
+{{- $ConfigKey     := "platen.display.table_of_contents"                        -}}
+{{- $SiteConfigToC := partialCached $getKey $ConfigKey $ConfigKey               -}}
+{{- $PageConfigToC := page.Params.platen.table_of_contents | default (dict)     -}}
+{{- $MergeParams   := dict "BaseMap" $SiteConfigToC "MergingMap" $PageConfigToC -}}
+{{- $MergedConfig  := partialCached $getMergedMap $MergeParams $MergeParams     -}}
+
+{{/*  Initialize the canonicalized map to return  */}}
+{{- $canonical := dict -}}
+
+{{/* Parse settings for minimum and maximum heading levels to include in ToC */}}
+{{- $MinLevel       := $MergedConfig.minimum_level | default 2     -}}
+{{- $MaxLevel       := $MergedConfig.maximum_level | default 4     -}}
+{{- $ExpandIcon     := $MergedConfig.expand_icon   | default ""    -}}
+{{- $CollapseIcon   := $MergedConfig.collapse_icon | default ""    -}}
+{{- $UseLegacy      := $MergedConfig.use_legacy    | default false -}}
+{{- $UseOrderedList := $MergedConfig.ordered_list  | default false -}}
+
+{{/*  Initialize the template to use  */}}
+{{- $template := "default" -}}
+
+{{/* Find all headings in the rendered content */}}
+{{- $FindHeadingsPattern := `<h[1-6].*?>(.|\n)+?</h[1-6]>`           -}}
+
+{{/* If no headings are found, leave canonical as an empty map */}}
+{{- with $FoundHeadings := findRE $FindHeadingsPattern $PageContent -}}
+  {{/*  Initialize the slice of headings  */}}
+  {{- $headings := slice -}}
+
+  {{/*
+      Loop over the found headings, adding their fully parsed info to the list
+      if they're in the valid range.
+  */}}
+  {{- range $Heading := $FoundHeadings -}}
+    {{- with $Parsed := partialCached $parseHeading $Heading $Heading -}}
+      {{- if and (ge $Parsed.Level $MinLevel) (le $Parsed.Level $MaxLevel) -}}
+        {{- $headings = $headings | append $Parsed -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/*  Get the full map of headings with their children  */}}
+  {{- $headings  = partial $canonicalizeHeadings (dict "Headings" $headings) -}}
+  {{- $canonical = merge $canonical (dict "Headings" $headings)              -}}
+
+  {{/*  Handle legacy vs shoelace  */}}
+  {{- if $UseLegacy -}}
+    {{- $template  = "legacy"                                    -}}
+    {{- $ListType  := cond   $UseOrderedList "ol" "ul"           -}}
+    {{- $ListOpen  := printf "<%s>"  $ListType | safeHTML        -}}
+    {{- $ListClose := printf "</%s>" $ListType | safeHTML        -}}
+    {{- $List      := dict   "Open" $ListOpen "Close" $ListClose -}}
+    {{- $canonical  = merge  $canonical (dict "List" $List)      -}}
+  {{- else -}}
+    {{/*  Handle icons  */}}
+    {{- if and $ExpandIcon $CollapseIcon -}}
+      {{- $Icons    := dict "Expand" $ExpandIcon "Collapse" $CollapseIcon -}}
+      {{- $canonical = merge $canonical (dict "Icons" $Icons)             -}}
+    {{- end -}}
+
+    {{/*  Handle list attributes  */}}
+    {{- $listAttributes := slice -}}
+    {{- $classes        := slice -}}
+    {{/*  Add no-rotate-icon if using custom icons  */}}
+    {{- if isset $canonical "Icons" -}}
+      {{- $classes = $classes | append "no-rotate-icon" -}}
+    {{- end -}}
+
+    {{- with $classes -}}
+      {{- $ClassAttribute := printf `class="%s"` (delimit $classes " ") -}}
+      {{- $listAttributes  = $listAttributes | append $ClassAttribute   -}}
+    {{- end -}}
+
+    {{/*  If the indentation settings are set, add them as a style to the tree  */}}
+    {{- with $MergedConfig.indentation -}}
+      {{- $indentStyles := slice -}}
+
+      {{- range $name, $value := $MergedConfig.indentation -}}
+        {{- $Variable    := printf "--indent-%s" (replace $name "_" "-") -}}
+        {{- $StyleEntry  := printf "%s: %s" $Variable (print $value)     -}}
+        {{- $indentStyles = $indentStyles | append $StyleEntry           -}}
+      {{- end -}}
+
+      {{- $StyleAttribute := printf `style="%s"` (delimit $indentStyles "; ") -}}
+      {{- $listAttributes  = $listAttributes | append $StyleAttribute         -}}
+    {{- end -}}
+
+    {{/*  If the tree has attributes, canonicalize them for insertion  */}}
+    {{- with $listAttributes -}}
+      {{- $listAttributes = delimit $listAttributes " " | safeHTMLAttr -}}
+      {{- $listAttributes = dict    "ListAttributes" $listAttributes   -}}
+      {{- $canonical      = merge   $canonical       $listAttributes   -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  As a last step, put the template in the correct folder  */}}
+{{- $template  = printf "platen/toc/templates/%s"  $template  -}}
+{{- $canonical = merge $canonical (dict "Template" $template) -}}
+
+{{- return $canonical -}}

--- a/modules/platen/layouts/partials/platen/toc/generate.html
+++ b/modules/platen/layouts/partials/platen/toc/generate.html
@@ -1,126 +1,27 @@
 {{/*
-    Docs.Partial: generate
+  Docs.Partial: generate
+
+  This partial generates and renders the table of contents for a page.
+
+  It expects input as a map with the following keys:
+
+  - `ForMobile` - A boolean value indicating whether the TOC is being rendered
+    for the mobile view or desktop. When this value is `true`, the ID for the
+    TOC has `Mobile` added to it.
+  
+  The partial calls `_canonicalize` to get the template and parameters for
+  rendering the TOC. It renders the TOC inside a nav element.
 */}}
-{{- $pageContent   := page.Content                                              -}}
-{{- $ConfigKey     := "platen.display.table_of_contents"                        -}}
-{{- $SiteConfigToC := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
-{{- $PageConfigToC := page.Params.platen.table_of_contents                      -}}
+{{- $Params    := .                 -}}
+{{- $ForMobile := $Params.ForMobile -}}
 
-{{/* Parse settings for minimum and maximum heading levels to include in ToC */}}
-{{- $MinLevel := $PageConfigToC.minimum_level | default $SiteConfigToC.minimum_level | default 2 -}}
-{{- $MaxLevel := $PageConfigToC.maximum_level | default $SiteConfigToC.maximum_level | default 4 -}}
-
-{{/* Build Regex to find includable headings. */}}
-{{- $headerFullPattern := printf "<h[%v-%v].*?>(.|\n)+?</h[%v-%v]>"
-                          $MinLevel $MaxLevel $MinLevel $MaxLevel
--}}
-{{- $headerTextPattern := printf "<h[%v-%v].*?>((.|\n)+?)</h[%v-%v]>"
-                          $MinLevel $MaxLevel $MinLevel $MaxLevel
--}}
-
-{{/* Build Regex to find heading levels. */}}
-{{- $levelPattern := printf "[%v-%v]" $MinLevel $MaxLevel -}}
-
-{{/* Parse settings to determine if the items should be in ordered or unordered lists */}}
-{{- $UseOrderedList := $PageConfigToC.ordered_list
-                       | default $SiteConfigToC.ordered_list
-                       | default false
--}}
-{{- $ListType := cond $UseOrderedList "ol" "ul" -}}
-
-{{/* Create open and closing list tags for convenience */}}
-{{- $OpenList  := printf "<%s>"  $ListType | safeHTML -}}
-{{- $CloseList := printf "</%s>" $ListType | safeHTML -}}
-
-{{/* Find all headings in the rendered content */}}
-{{- $headers     := findRE $headerFullPattern $pageContent -}}
-{{- $has_headers := ge (len $headers) 1                    -}}
-{{- if $has_headers -}}
-
-{{- $largest := 6 -}}
-{{- range $headers -}}
-  {{- $headerLevel := index (findRE $levelPattern . 1) 0 -}}
-  {{- $headerLevel := len (seq $headerLevel)             -}}
-  {{- if lt $headerLevel $largest -}}
-    {{- $largest = $headerLevel -}}
-  {{- end -}}
+{{- $id := "TableOfContents" -}}
+{{- if eq true $ForMobile -}}
+  {{- $id = printf "%sMobile" $id -}}
 {{- end -}}
 
-{{- $firstHeaderLevel := len (seq (index (findRE $levelPattern (index $headers 0) 1) 0)) -}}
+{{- $Canonical := partial "platen/toc/_canonicalize" -}}
 
-{{- $.Scratch.Set "bareul" slice -}}
-<nav id="TableOfContents">
-{{ $OpenList }}
-  {{- range seq (sub $firstHeaderLevel $largest) -}}
-    {{ $OpenList }}
-    {{- $.Scratch.Add "bareul" (sub (add $largest .) 1) -}}
-  {{- end -}}
-  {{- range $index, $header := $headers -}}
-    {{- $headerLevel := index (findRE $levelPattern . 1) 0 -}}
-    {{- $headerLevel := len (seq $headerLevel) -}}
-
-    {{/* get id="xyz" */}}
-    {{- $id := index (findRE "(id=\"(.*?)\")" $header 9) 0 -}}
-
-    {{/* strip id="" to leave xyz (no way to get regex capturing groups in hugo :( */}}
-    {{- $cleanedID := replace (replace $id "id=\"" "") "\"" "" -}}
-
-    {{/* Get header text, stripped of anchor and leading/trailing whitespace */}}
-    {{- $header := replaceRE $headerTextPattern          "$1" $header -}}
-    {{- $header := replaceRE "<a class=\"anchor\".*</a>" ""   $header -}}
-    {{- $header := replaceRE "\n"                        ""   $header -}}
-    {{- $header := trim $header " "                                   -}}
-
-    {{- if ne $index 0 -}}
-      {{- $prevHeader      := index $headers (sub $index 1)                      -}}
-      {{- $prevHeaderLevel := index (findRE $levelPattern $prevHeader 1) 0 | int -}}
-        {{/* Handle nested lists based on level */}}
-        {{- if gt $headerLevel $prevHeaderLevel -}}
-          {{- range seq $prevHeaderLevel (sub $headerLevel 1) -}}
-            {{ $OpenList }}
-            {{/* the first should not be recorded */}}
-            {{- if ne $prevHeaderLevel . -}}
-              {{- $.Scratch.Add "bareul" . -}}
-            {{- end -}}
-          {{- end -}}
-        {{- else -}}{{/* Item is at the same level as or lower than previous header */}}
-          </li>
-          {{- if lt $headerLevel $prevHeaderLevel -}}
-            {{- range seq (sub $prevHeaderLevel 1) -1 $headerLevel -}}
-              {{- if in ($.Scratch.Get "bareul") . -}}
-                {{ $CloseList }}
-                {{/* manually do pop item */}}
-                {{- $tmp := $.Scratch.Get "bareul" -}}
-                {{- $.Scratch.Delete "bareul" -}}
-                {{- $.Scratch.Set "bareul" slice}}
-                {{- range seq (sub (len $tmp) 1) -}}
-                  {{- $.Scratch.Add "bareul" (index $tmp (sub . 1)) -}}
-                {{- end -}}
-              {{- else -}}
-                {{ $CloseList }}</li>
-              {{- end -}}
-            {{- end -}}
-          {{- end -}}
-        {{- end -}}
-        <li>
-          <a href="#{{- $cleanedID  -}}">{{- $header | safeHTML -}}</a>
-    {{- else -}}
-    <li>
-      <a href="#{{- $cleanedID -}}">{{- $header | safeHTML -}}</a>
-    {{- end -}}
-  {{- end -}}
-
-  {{- $firstHeaderLevel := $largest                                           -}}
-  {{- $lastHeader       := index $headers (sub (len $headers) 1)              -}}
-  {{- $lastHeaderLevel  := int (index (findRE $levelPattern $lastHeader 1) 0) -}}
-  </li>
-  {{- range seq (sub $lastHeaderLevel $firstHeaderLevel) -}}
-    {{- if in ($.Scratch.Get "bareul") (add . $firstHeaderLevel) -}}
-      {{ $CloseList }}
-    {{- else -}}
-      {{ $CloseList }}</li>
-    {{- end -}}
-  {{- end -}}
-{{ $CloseList }}
+<nav id="{{ $id | safeHTMLAttr }}">
+  {{ partial $Canonical.Template $Canonical }}
 </nav>
-{{- end -}}

--- a/modules/platen/layouts/partials/platen/toc/templates/default.html
+++ b/modules/platen/layouts/partials/platen/toc/templates/default.html
@@ -1,0 +1,111 @@
+{{/*
+    TOC Template: default
+
+    This template renders the TOC as a Shoelace tree element (`<sl-tree>`),
+    with each heading as a tree item (`<sl-tree-item>`). If a heading has any
+    children, they're added as nested tree items.
+
+    This partial expects input as a dictionary with the following keys:
+
+    - `Headings` - (Mandatory) The canonicalized slice of parsed headings with
+      any child headings mapped to them.
+    - `Icons` - (Optional) A dictionary with both keys `Collapse` and `Expand`
+      set, or an empty dictionary.
+    - `ListAttributes` - (Optional) A string representing the attribute-value
+      pairs to add to the `<sl-tree>` element.
+
+    If `Icons` is not an empty dictionary, the template calls the icons
+    sub-template, which renders a pair of `<sl-icon>` elements for the tree.
+    The icons are used for indicating whether a tree item can be expanded or
+    collapsed.
+
+    For each heading, the template calls the entry sub-template. That template
+    handles adding the `<sl-tree-item>` for the heading.
+
+    If the `toc_expand` attribute was set to `true` in the heading's markdown,
+    or it wasn't set and the heading has children, the tree item gets the
+    `expanded` attribute.
+
+    If the `toc_classes` attribute was set in the heading's markdown, the tree
+    item gets the `class` attribute with that value.
+
+    Inside the tree item, each heading gets a link to the heading on the page.
+    The link always displays the heading's HTML without the anchor element and
+    with nested links unlinked.
+
+    If the `toc_prefix_icon` and/or `toc_suffix_icon` attributes were set in
+    the heading's markdown, the template inserts the appropriate icon before or
+    after the heading's text.
+
+    If the heading has child headings, they are recursively added after the
+    link in their own `<sl-tree-item>` elements.
+*/}}
+
+{{- $Params         := .                                                  -}}
+{{- $Headings       := $Params.Headings                                   -}}
+{{- $Icons          := $Params.Icons                                      -}}
+{{- $ListAttributes := $Params.ListAttributes | default "" | safeHTMLAttr -}}
+
+
+<sl-tree {{ $ListAttributes }}>
+  {{- with $Icons }}
+    {{ partial "platen/toc/templates/default/icons" $Icons }}
+  {{ end -}}
+  {{ range $Heading := $Headings }}
+    {{ partial "platen/toc/templates/default/entry" $Heading }}
+  {{ end }}
+</sl-tree>
+
+{{- define "partials/platen/toc/templates/default/entry" -}}
+  {{- $IconTemplate  := "platen/features/shoelace/templates/icon"       -}}
+  {{- $ChildTemplate := "platen/toc/templates/default/entry"            -}}
+  {{- $Heading       := .                                               -}}
+  {{- $ID            := $Heading.ID                                     -}}
+  {{- $Attributes    := $Heading.Attributes                             -}}
+  {{- $Children      := $Heading.Children                               -}}
+  {{- $text          := $Heading.Text                                   -}}
+  {{- $SuffixIcon    := $Attributes.toc_suffix_icon                     -}}
+  {{- $PrefixIcon    := $Attributes.toc_prefix_icon                     -}}
+  {{- $Classes       := $Attributes.toc_classes     | default (slice)   -}}
+  {{- $Expand        := $Attributes.toc_expand      | default $Children -}}
+
+  {{- if $Attributes.toc_text -}}
+    {{- $text = $Attributes.toc_text -}}
+  {{- else if $Attributes.toc_md -}}
+    {{- $text = $Attributes.toc_md | page.RenderString -}}
+  {{- else if $Attributes.toc_id_as_code -}}
+    {{- $text = printf "<code>%s</code>" $ID -}}
+  {{- end -}}
+
+  <sl-tree-item
+    {{- if $Expand }} expanded {{- end -}}
+    {{- with $Classes }} class="{{ $Classes }}" {{- end -}}
+  >
+
+    <a href="#{{ $ID }}">
+      {{- with $PrefixIcon }}
+        {{ partial $IconTemplate (dict "Page" page "Icon" $PrefixIcon) }}
+      {{ end -}}
+
+      {{ $text | safeHTML }}
+
+      {{- with $SuffixIcon }}
+        {{ partial $IconTemplate (dict "Page" page "Icon" $SuffixIcon) }}
+      {{ end -}}
+    </a>
+
+    {{ range $Child := $Heading.Children }}
+      {{ partial $ChildTemplate $Child }}
+    {{ end }}
+  </sl-tree-item>
+{{- end -}}
+
+{{- define "partials/platen/toc/templates/default/icons" -}}
+  {{- $Icons        := .                                                              -}}
+  {{- $Collapsing   := dict "Page" page "Slot" "collapse-icon" "Icon" $Icons.Collapse -}}
+  {{- $Expanding    := dict "Page" page "Slot" "expand-icon"   "Icon" $Icons.Expand   -}}
+  {{- $IconTemplate := "platen/features/shoelace/templates/icon"                      -}}
+
+  {{ partial $IconTemplate $Collapsing }}
+  {{ partial $IconTemplate $Expanding  }}
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/toc/templates/legacy.html
+++ b/modules/platen/layouts/partials/platen/toc/templates/legacy.html
@@ -1,0 +1,39 @@
+{{/*
+    TOC Template: Legacy
+
+    This template renders the TOC as an ordered or unordered list with the link
+    to each heading as an entry in the list. For headings with children, it
+    creates a nested list.
+
+    The link for each heading points to the heading's ID and displays the
+    heading's HTML, but without the anchor element or nested links.
+
+    This template is deprecated and will eventually be removed.
+*/}}
+{{- $Params   := .                -}}
+{{- $Headings := $Params.Headings -}}
+{{- $List     := $Params.List     -}}
+
+{{ $List.Open }}
+  {{ range $Heading := $Headings }}
+    {{- $Entry := dict "Heading" $Heading "List" $List    }}
+    {{ partial "platen/toc/templates/legacy/entry" $Entry }}
+  {{ end }}
+{{ $List.Close }}
+
+{{- define "partials/platen/toc/templates/legacy/entry" -}}
+  {{- $Entry    := .              -}}
+  {{- $Heading  := $Entry.Heading -}}
+  {{- $List     := $Entry.List     }}
+  <li>
+    <a href="#{{ $Heading.ID }}">{{ $Heading.Text | safeHTML }}</a>
+    {{ with $Heading.Children }}
+      {{ $List.Open }}
+        {{ range $Child := $Heading.Children }}
+          {{- $Entry := dict "Heading" $Child "List" $List      }}
+          {{ partial "platen/toc/templates/legacy/entry" $Entry }}
+        {{ end }}
+      {{ $List.Close }}
+    {{ end }}
+  </li>
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/toc/utils/canonicalize/headings.html
+++ b/modules/platen/layouts/partials/platen/toc/utils/canonicalize/headings.html
@@ -1,0 +1,79 @@
+{{/*
+    TOC Canonicalize Partial: headings
+
+    This partial converts a slice of parsed headings into a canonicalized slice
+    of headings with their children defined as a slice of parsed headings. It
+    handles nested child headings.
+
+    This partial expects to receive input as a dictionary with the following
+    keys:
+
+    - `Headings` - The slice of parsed headings for a content page in the order
+      they were discovered in the content.
+
+    This partial loops over the headings, calling the mapHeading partial for
+    each heading. After a heading is processed, the partial updates the list of
+    processed headings. When the mapHeading partial is called again, the
+    parameters include the updated list of processed headings and the result
+    from the last call as the `Previous` parameter. It always passes the
+    current heading in the loop for the `Heading` parameter.
+
+    The partial records the results in a map with the heading's ID as the key
+    for itself. This ensures the partial can update a previously mapped heading
+    if the next heading is actually a child heading.
+
+    After fully mapping the headings, this partial canonicalizes the map of
+    headings into a slice in the same order the headings were discovered in,
+    but now with any child headings added under the Children key in their
+    parent heading's map.
+
+    This partial returns the canonicalized slice of heading maps.
+*/}}
+
+{{- $Params   := .                -}}
+{{- $Headings := $Params.Headings -}}
+
+{{- $mapHeading := "platen/toc/utils/canonicalize/mapHeading" -}}
+{{- $mapToList  := "platen/toc/utils/canonicalize/mapToList"  -}}
+
+
+{{- $mappingHeadings := dict  -}}
+{{- $processed       := slice -}}
+{{- $previous        := dict  -}}
+
+{{/*  Loop over the headings, calling mapHeadings for each */}}
+{{- range $Index, $H := $Headings -}}
+  {{/*  Add the first heading to the map before the mapping starts  */}}
+  {{- if eq $Index 0 -}}
+    {{- $mappingHeadings = merge $mappingHeadings (dict $H.ID $H) -}}
+  {{- end -}}
+
+  {{/*  Only recurse for headings that haven't already been processed  */}}
+  {{- if not (in $processed $H.ID) -}}
+    {{- $Mapping := dict
+          "Heading"   $H
+          "Headings"  $Headings
+          "Previous"  $previous
+          "Processed" $processed
+    -}}
+    {{- $Result         := partial $mapHeading $Mapping          -}}
+    {{- $processed       = union $processed $Result.Processed    -}}
+    {{- $previous        = $Result.Mapped                        -}}
+    {{- $MappedHeading  := dict $Result.Mapped.ID $Result.Mapped -}}
+    {{- $mappingHeadings = merge $mappingHeadings $MappedHeading -}}
+  {{- end -}}
+{{- end -}}
+
+{{- $headingIDs := slice -}}
+{{- range $H := $Headings -}}
+  {{- $headingIDs = $headingIDs | append $H.ID -}}
+{{- end -}}
+
+{{/*  With the headings mapped, build the canonical slice in order  */}}
+{{- $Canonicalizing := dict "HeadingIDs"      $headingIDs
+                            "FoundHeadings"   $Headings
+                            "MappingHeadings" $mappingHeadings 
+-}}
+{{- $CanonicalHeadings := partial $mapToList $Canonicalizing -}}
+
+{{- return $CanonicalHeadings -}}

--- a/modules/platen/layouts/partials/platen/toc/utils/canonicalize/mapHeading.html
+++ b/modules/platen/layouts/partials/platen/toc/utils/canonicalize/mapHeading.html
@@ -1,0 +1,227 @@
+{{/*
+    TOC Canonicalize Partial: mapHeading
+
+    This partial processes a list of headings to build them into a map where
+    child headings are added to their parent. That way, the templates can write
+    the entries for the TOC without having to check whether they're closing the
+    prior entries.
+
+    The only mandatory parameter for this partial is `Headings`, which is 
+
+    This partial expects input as a dictionary with the following keys:
+
+    - `Headings` - the slice of parsed headings from the content before
+      mapping starts. This slice isn't referenced but not modified because it
+      represents the unmunged headings in the order they were discovered in
+      the content.
+    - `Heading` - the current heading being mapped from the caller.
+    - `Parent` - A heading with at least one known child heading. This value is
+      only set when processing a heading that is discovered to be a child of
+      the previous heading.
+    - `Previous` - The last processed heading. After processing a heading, the
+      partial updates this value.
+    - `Processed` = The list of processed heading IDs. This is used to prevent
+      double-processing the same heading. This partial updates the value in
+      place and always returns it.
+
+    The partial iterates over the unprocessed headings list to build a map of
+    headings with their children. If a later heading is discovered to be a
+    child of a previous heading, it's added to that heading in the Child key
+    for the heading's map.
+
+    It recursively calls itself as needed, mapping the parent-child
+    relationships for deeply nested headings.
+
+    This partial returns output as a dictionary with the following keys:
+
+    - `Mapped` -  The mapped Heading. This value depends on the input and
+      processing results for the file.
+
+      When the `Parent` parameter is passed, this value represents the updated
+      parent heading with any discovered children.
+
+      When the `Parent` parameter isn't passed and the processed heading is at
+      the same level as the previous heading, it returns the processed heading.
+
+      When the `Parent` parameter isn't passed and the processed heading is
+      discovered to be a child of the previous heading, it recurses with the
+      previous heading as the `Parent` parameter and then returns the previous
+      heading with its mapped children.
+    - `Processed` - The list of processed heading IDs after the partial
+      finishes the current processing pass for its input.
+*/}}
+
+{{- $Params    := .                                   -}}
+{{- $Heading   := $Params.Heading   | default (dict)  -}}
+{{- $Headings  := $Params.Headings  | default (slice) -}}
+{{- $parent    := $Params.Parent    | default (dict)  -}}
+{{- $previous  := $Params.Previous  | default (dict)  -}}
+{{- $processed := $Params.Processed | default (slice) -}}
+
+{{/*  Define Recurse for easier calling/renaming */}}
+{{- $Recurse := "platen/toc/utils/canonicalize/mapHeading" -}}
+
+{{/*  Initialize the returned information.  */}}
+{{- $info   := dict -}}
+
+{{/*
+    We need to tell the difference between when the partial was called to
+    get a parent's children and when it was discovered that a heading is
+    actually a child of the previous heading.
+
+    Similarly, to make things work smoothly, we need to pre-define an empty
+    dict for nested parents. This is only used when we are processing
+    headings for a parent and discover deeper nesting.
+*/}}
+{{- $PassedParent := ne (dict) $parent -}}
+{{- $nestedParent := dict              -}}
+
+{{- $keepProcessing := true -}}
+{{- range $H := $Headings -}}
+  {{/*  Don't re-process headings and stop processing when required.  */}}
+  {{- if and $keepProcessing (not (in $processed $H.ID)) -}}
+    {{- if $parent -}}
+      {{/*  Only called when passed a parent.  */}}
+      {{- if gt $H.Level $parent.Level -}}
+        {{- if eq $H.Level (add 1 $parent.Level) -}}
+          {{/*
+              In this case, the current heading is a direct child of the
+              parent heading. We need to add this heading the parent's map
+              of children, set this heading as the previous heading, and
+              add its ID to the list of processed IDs before continuing.
+          */}}
+          {{- $children := $parent.Children | default (dict)         -}}
+          {{- $children  = merge $children (dict $H.ID $H)           -}}
+          {{- $parent    = merge $parent (dict "Children" $children) -}}
+          {{- $previous  = $H                                        -}}
+          {{- $processed = $processed | append $H.ID | uniq          -}}
+        {{- else if eq $H.Level (add 1 $previous.Level) -}}
+          {{/*
+              In this case, the current heading is actually a child of the
+              previous heading, which makes it a nested parent. We need to
+              immediately recurse, passing the previous heading as the
+              parent heading.
+
+              When we get the result, we need to merge the updated map for
+              the nested parent heading and its children into the current
+              parent's map of children. Then we update the list of
+              processed IDs and set the previous heading to the mapped
+              heading returned from the recursive call.
+          */}}
+          {{- $nestedParent = $previous -}}
+          {{- $Recursing     := merge $Params (
+                dict
+                "Heading"   $H
+                "Parent"    $nestedParent
+                "Processed" $processed
+              )
+          -}}
+          {{- $Result         := partial $Recurse $Recursing                              -}}
+          {{- $Mapped         := $Result.Mapped                                           -}}
+          {{- $nestedChildren := $nestedParent.Children | default (dict)                  -}}
+          {{- $nestedChildren  = merge $nestedChildren  (dict $Mapped.ID $Mapped)         -}}
+          {{- $nestedParent    = merge $nestedParent    (dict "Children" $nestedChildren) -}}
+          {{- $children       := $parent.Children       | default (dict)                  -}}
+          {{- $children        = merge $children        (dict $Mapped.ID $Mapped)         -}}
+          {{- $parent          = merge $parent          (dict "Children" $children)       -}}
+          {{- $processed       = union $processed       $Result.Processed                 -}}
+          {{- $previous        = $Mapped                                                  -}}
+          {{/*  Reset the nested parent before continuing  */}}
+          {{- $nestedParent = dict -}}
+        {{- else -}}
+          {{/*
+              In this case, the current heading has skipped at least one
+              level. We raise an error here, because skipping heading
+              levels breaks accessibility for site visitors.
+          */}}
+          {{- $Message := delimit (
+                slice
+                (printf "Unable to build table of contents on '%s'."     page.File.Path)
+                (printf "The heading '%s' with the ID '%s' is level %v," $H.Text $H.ID $H.Level)
+                (printf "but the previous heading (id '%s') was level %v." $previous.ID $previous.Level)
+                "Headings must only ever increment one level at a time."
+                "Otherwise, they present accessibility problems for site visitors."
+                "For more information, see:"
+                "https://www.w3.org/WAI/tutorials/page-structure/headings/"
+              ) " " | print
+          -}}
+          {{- errorf $Message -}}
+        {{- end -}}
+      {{- else -}}
+        {{/*
+            In this case, the parent heading isn't an ancestor of the
+            current heading. We stop processing, because we've got the
+            fully mapped parent with its children. This heading isn't added
+            to the list of processed headings, so it can be processed with
+            this parent as the previous heading.
+        */}}
+        {{- $keepProcessing = false -}}
+      {{- end -}}
+    {{- else if $previous -}}
+      {{/*
+          This conditional means the current heading isn't known to have a
+          parent and isn't the first heading in the page. If this heading
+          does actually have a parent, a recursive call ensures we update
+          the map as needed.
+      */}}
+      {{- if gt $H.Level $previous.Level -}}
+        {{/*
+            In this case, the heading is actually a child of the previous
+            heading. We need to immediately recurse with the previous
+            heading as the parent.
+
+            When we get the result, we should have the "fully" mapped
+            parent heading with its children. We want to return that, not
+            the current heading. That way we can replace the entry for the
+            previous heading in the working map.
+        */}}
+        {{- $Recursing := merge $Params (
+              dict
+              "Heading"   $H
+              "Parent"    $previous
+              "Processed" $processed
+            )
+        -}}
+        {{- $Result   := partial $Recurse $Recursing                -}}
+        {{- $processed = union $processed $Result.Processed         -}}
+        {{- $previous  = $Result.Mapped                             -}}
+        {{- $info      = merge $info (dict "Mapped" $Result.Mapped) -}}
+      {{- else -}}
+        {{/*
+            In this case, the heading is a sibling of the previous heading.
+            Set it as the mapped heading and add the ID to the processed
+            list.
+        */}}
+        {{- $info      = merge $info (dict "Mapped" $H) -}}
+        {{- $processed = $processed | append $H.ID | uniq -}}
+      {{- end -}}
+      {{/*
+          For headings without a parent that have a previous heading, we
+          only process that entry. Only the first heading and headings with
+          a parent keep processing.
+      */}}
+      {{- $keepProcessing = false -}}
+    {{- else if eq $H $Heading -}}
+      {{/*
+          When processing itself, just set this heading as the previous one
+          and add it to the list of processed IDs.
+      */}}
+      {{- $previous  = $H                        -}}
+      {{- $processed = $processed | append $H.ID -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  Always return the updated list of processed headings  */}}
+{{- $info = merge $info (dict "Processed" $processed) -}}
+
+{{/*
+    If called for a parent, return the parent as the mapped heading. This
+    ensures the return info when passed a parent is that heading with it's
+    children, enabling the partial to update the map appropriately.
+*/}}
+{{- if $PassedParent -}}
+  {{- $info = merge $info (dict "Mapped" $parent) -}}
+{{- end -}}
+
+{{- return $info -}}

--- a/modules/platen/layouts/partials/platen/toc/utils/canonicalize/mapToList.html
+++ b/modules/platen/layouts/partials/platen/toc/utils/canonicalize/mapToList.html
@@ -1,0 +1,57 @@
+{{/*
+    TOC Canonicalize Partial: mapToList
+
+    This partial converts the dictionary of mapped headings with their children
+    into the correctly ordered slice of headings, so they can be looped over
+    when rendering the TOC.
+
+    This partial expects to receive input as a dictionary as with the following
+    keys:
+
+    - `HeadingIDs` - The list of IDs for the mapped headings.
+    - `FoundHeadings` - The slice of parsed headings in the order they were
+      found in the processed content. This order is used as the canonical
+      ordering for the headings.
+    - `MappingHeadings` - The map of headings with their children. The key for
+      the top level map is always the ID of the heading it represents. For
+      headings with the Children key, defined, the value is always a map of
+      headings with their ID as the key.
+
+    This partial iterates over the found headings in the order they appeared in
+    the content, looking for the matching ID in the mapping headings. If the
+    IDs match, that heading will be added to the slice.
+    
+    Before adding the heading to the slice, the partial checks to see if the
+    heading has any child headings. If it does, the partial recurses, using the
+    child headings as the value for MappingHeadings.
+
+    After the children for a heading are recursively resolved, the heading is
+    added to the canonical slice.
+
+    This partial returns a slice where each entry is a heading map and the
+    entries are in the order the headings appeared in the content. If the
+    heading has children, they are represented as a slice of headings in the
+    correct order. Children are recursively resolved.
+*/}}
+{{- $Params          := .                                        -}}
+{{- $HeadingIDs      := $Params.HeadingIDs                       -}}
+{{- $FoundHeadings   := $Params.FoundHeadings                    -}}
+{{- $MappingHeadings := $Params.MappingHeadings                  -}}
+{{- $canonical       := slice                                    -}}
+
+{{- $Recursing := dict "HeadingIDs" $HeadingIDs "FoundHeadings" $FoundHeadings -}}
+{{- range $Heading := $FoundHeadings -}}
+  {{- if in $HeadingIDs $Heading.ID -}}
+    {{- with $mappedHeading := index $MappingHeadings $Heading.ID -}}
+      {{- with $children := $mappedHeading.Children -}}
+        {{- $Recursing    := merge $Recursing (dict "MappingHeadings" $children) -}}
+        {{- $children      = partial "platen/toc/utils/canonicalize/mapToList" $Recursing        -}}
+        {{- $mappedHeading = merge $mappedHeading (dict "Children" $children)    -}}
+      {{- end -}}
+
+      {{- $canonical = $canonical | append $mappedHeading -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $canonical -}}

--- a/modules/platen/layouts/partials/platen/toc/utils/mungeHeadingInner.html
+++ b/modules/platen/layouts/partials/platen/toc/utils/mungeHeadingInner.html
@@ -1,0 +1,65 @@
+{{/*
+    TOC Utility Partial: mungeHeadingInner
+
+    This partial munges the inner HTML for a parsed heading to remove the
+    anchor element added by Platen's default render hook and to unlink any
+    other text in the heading for the TOC.
+
+    It expects to receive an HTML string as input.
+*/}}
+
+{{- $Inner  := . -}}
+{{- $munged := . -}}
+
+{{/*
+    This pattern finds the Platen-added anchor in a heading so it can be
+    removed. The components are:
+
+    - `<a[^>]*?class="[^\x22]*anchor[^\x22]*"[^>]*>`
+
+      Looks for a link element with the anchor class.
+    - `.*?`
+
+      Matches any inner text.
+    - `<\/a>`
+
+      Matches the closing of the element.
+*/}}
+{{- $AnchorPattern := delimit (
+      slice
+      `<a[^>]*?class="[^\x22]*anchor[^\x22]*"[^>]*>`
+      `.*?`
+      `<\/a>`
+    ) "" | print
+-}}
+
+{{/*
+    This pattern finds nested links in the HTML so they can be replaced by
+    their inner HTML only, effectively removing the nested links. The
+    components are:
+
+    - `\n?<a.*?>`
+
+      Optionally matches a newline followed by a link element.
+    - `(?:\s*)?((?:.|\s)*?)(?:\s*)?`
+      
+      Optionally matches any amount of whitespace, followed by the inner HTML
+      of the link, followed by any amount of whitespace. It captures only the
+      inner HTML between the wrapping whitespace.
+    - `<\/a>\n?`
+
+      Matches the closing for the link element followed by an optional newline.
+*/}}
+{{- $NestedLinkPattern := delimit (
+      slice
+      `\n?<a.*?>`
+      `(?:\s*)?((?:.|\s)*?)(?:\s*)?`
+      `<\/a>\n?`
+    ) "" | print
+-}}
+
+{{- $munged = replaceRE $AnchorPattern     ""   $munged -}}
+{{- $munged = replaceRE $NestedLinkPattern "$1" $munged -}}
+{{- $munged = trim      $munged            " \n"        -}}
+
+{{- return $munged -}}

--- a/modules/platen/layouts/partials/platen/toc/utils/parseHeading.html
+++ b/modules/platen/layouts/partials/platen/toc/utils/parseHeading.html
@@ -1,0 +1,96 @@
+{{/*
+    TOC Utility Partial: parseHeading
+
+    This partial parses a string containing an HTML heading element to return
+    a map of the element's values.
+
+    The return map for the heading always includes:
+
+    - `HTML`: The raw HTML for the heading, as passed to this partial.
+    - `Level`: An integer representing the heading's level. Always between one
+      and six, inclusive.
+    - `ID`: The `id` attribute for the heading, also known as its anchor.
+    - `Text`: An HTML string representing the inner HTML for the heading. This
+      string is munged to remove the Platen-added anchor element and to remove
+      the wrapping `<a></a>` from any nested links in the heading, since those
+      will break the TOC.
+    - `Attributes`: The map of attributes passed to the heading from markup, if
+      the heading was handled by Platen on a content page. This isn't populated
+      if the attributes were added with `markdownify` or if the heading was
+      added by a shortcode or partial that didn't call `.RenderString` on the
+      page.
+*/}}
+{{- $Heading := . -}}
+{{/*  Define partials for easier usage and renaming  */}}
+{{- $mungeHeadingInner := "platen/toc/utils/mungeHeadingInner" -}}
+{{/*
+    This is the pattern that parses the heading's HTML. Each component of the
+    pattern is explained below:
+
+    - `<h([1-6])`
+
+      This component looks for the opening of the heading and captures the
+      heading's level.
+    - `[^>]*?`
+
+      This component looks for any number of any character except the closing
+      angle bracket for the heading, with a non-greedy match, to account for
+      any attributes on the heading before the `id` attribute.
+    - `id="([^\x22]*)"`
+
+      This component looks for the `id` attribute on the heading and captures its
+      value. If the heading doesn't have an `id` attribute, it doesn't match.
+    - `[^>]*>`
+
+      This component looks for any number of any character except the closing
+      angle bracket for the heading, to account for any attributes on the
+      heading after the `id` attribute. Then it matches the closing angle
+      bracket.
+
+    - `((?:.|\s)+?)`
+
+      This component captures all of the content inside the heading element as
+      a single, non-greedy match. If the heading has no inner content, it
+      doesn't match the regex.
+    - `<\/h[1-6]>`
+
+      This component matches the closing of the heading element.
+*/}}
+{{- $Pattern := delimit (
+      slice
+      `<h([1-6])`
+      `[^>]*?`
+      `id="([^\x22]*)"`
+      `[^>]*>`
+      `((?:.|\s)+?)`
+      `<\/h[1-6]>`
+    ) "" | print
+-}}
+
+{{/*  Initialize the map of info for the parsed heading  */}}
+{{- $info := dict -}}
+
+{{/*  If the heading HTML is a match, populate the info map.  */}}
+{{- with $Matches := findRESubmatch $Pattern $Heading -}}
+  {{- $Match := index $Matches 0                                       -}}
+  {{- $HTML  := index $Match   0                                       -}}
+  {{- $Level := index $Match   1 | int                                 -}}
+  {{- $ID    := index $Match   2                                       -}}
+  {{- $Inner := index $Match   3                                       -}}
+  {{- $Text  := partialCached $mungeHeadingInner $Inner $Inner         -}}
+  {{- $info   = dict "HTML" $HTML "Level" $Level "ID" $ID "Text" $Text -}}
+
+  {{/*
+      If the partial has access to the top-level page, retrieve the heading
+      map and see if this heading's ID is set in it. If so, merge the passed
+      attributes for the heading into the info map.
+  */}}
+  {{- with page -}}
+    {{- $PageHeadingMap := page.Store.Get "_HeadingMap" | default (dict) -}}
+    {{- with $PageInfo := index $PageHeadingMap $ID -}}
+      {{- $info = merge $info (dict "Attributes" $PageInfo.Attributes) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $info -}}

--- a/modules/platen/layouts/partials/platen/utils/deepIndex.html
+++ b/modules/platen/layouts/partials/platen/utils/deepIndex.html
@@ -1,0 +1,23 @@
+{{- $Params  := .                                -}}
+{{- $value   := $Params.Data    | default (dict) -}}
+{{- $DotPath := $Params.DotPath | default ""     -}}
+
+{{- if and $value $DotPath -}}
+  {{- range $Key := split $DotPath "." -}}
+    {{- $value = index $value $Key -}}
+  {{- end -}}
+
+  {{- with $value -}}
+    {{/*  Nothing to do, the data was found  */}}
+  {{- else -}}
+    {{- warnf "Unable to index into dot-path key '%s' for input map" $DotPath -}}
+  {{- end -}}
+{{- else if $value -}}
+  {{- errorf "Missing mandatory parameter DotPath for deepIndex partial." -}}
+{{- else if $DotPath -}}
+  {{- errorf "Missing mandatory parameter Data for deepIndex partial." -}}
+{{- else -}}
+  {{- errorf "Missing mandatory parameters Data and DotPath for deepIndex partial." -}}
+{{- end -}}
+
+{{- return $value -}}

--- a/modules/platen/layouts/partials/platen/utils/getDisplayTitle.html
+++ b/modules/platen/layouts/partials/platen/utils/getDisplayTitle.html
@@ -1,0 +1,163 @@
+{{/*
+    Utility Partial: getDisplayTitle
+
+    This partial expects input as a dictionary with the following keys:
+
+    - Page: (Optional) The page the display title is for. If this value isn't
+      specified, the partial uses the current page instead.
+    - Title: (Mandatory) The canonical non-display title for the page. This is
+      used as the value between the page's `platen.title_prefix` and
+      `platen.title_suffix` options, if they're specified in the page's front
+      matter. If there's no prefix or suffix, this value is passed back as the
+      display title.
+    
+    This partial inspects the `platen.display_title` value for a page's front
+    matter for the following keys:
+
+    - markdown: A string to render as Markdown for the title. If this value
+      isn't set, the default page title is used.
+    - prefix: Either a string to render as Markdown before the title or a
+      dictionary of options. Valid options are `markdown` and `icon`. When
+      `icon` is defined, it's inserted before the prefixes `markdown`, if any.
+    - suffix: Either a string to render as Markdown after the title or a
+      dictionary of options. Valid options are `markdown` and `icon`. When
+      `icon` is defined, it's inserted after the prefixes `markdown`, if any.
+    
+    Examples:
+
+    1. Simple override:
+          title: Foo
+          platen:
+            display_title: Bar
+       Becomes:
+          "Bar"
+    2. Prefix and suffix:
+          title: Foo
+          platen:
+            display_title:
+              prefix:
+                icon: patch-exclamation-fill
+              suffix: "!"
+       Becomes:
+          <sl-icon name="patch-exclamation-fill"></sl-icon>&nbsp;Foo !
+    3. Full:
+          title: Foo
+          platen:
+            display_title:
+              markdown: _Bar_
+            prefix:
+              icon: gear
+              markdown: Foo!
+            suffix:
+              icon: hammer
+              markdown: Baz
+       Becomes:
+        <sl-icon name="gear"></sl-icon>&nbsp;Foo!&nbsp;<em>Bar</em> Baz <sl-icon name="hammer"></sl-icon>
+*/}}
+{{- $Params    := .                                                  -}}
+{{- $Page      := $Params.Page                      | default page   -}}
+{{- $PageTitle := $Params.Title                                      -}}
+{{- $Options   := $Page.Params.platen.display_title | default (dict) -}}
+{{/*  Define partials for easier reuse/maintenance  */}}
+{{- $resolveIconOptions := "platen/features/shoelace/utils/resolveIconOptions" -}}
+{{- $RenderIcon         := "platen/features/shoelace/templates/icon"           -}}
+{{/*
+    This pattern is used to look for rendering markup that must not be rendered
+    or it will break the semantics of the title.
+
+    If a markup starts with any of these items, they're separated from the rest
+    of the string before rendering and then re-added after.
+
+        1.    Ordered list.
+        1)    Ordered list.
+        -     Unordered list.
+        *     Unordered list.
+        +     Unordered list.
+        >     Block quote.
+*/}}
+{{- $LeadingMarkupPattern := `^(\d+(?:\.|\))|[-+>\*])?(.+)?` -}}
+{{/*  Initialize the display title to the canonical title.  */}}
+{{- $displayTitle := trim $PageTitle " " -}}
+
+{{- with $Options -}}
+  {{- if reflect.IsMap $Options -}}
+    {{- with $Options.markdown -}}
+      {{- with $LeadMatches := findRESubmatch $LeadingMarkupPattern $Options.markdown -}}
+        {{- $Match       := index $LeadMatches 0                                 -}}
+        {{- $Lead        := index $Match       1                                 -}}
+        {{- $Markdown    := index $Match       2                                 -}}
+        {{- $displayTitle = printf "%s%s" $Lead ($Markdown | $Page.RenderString) -}}
+      {{- else -}}
+        {{- $displayTitle = $Options.markdown | $Page.RenderString -}}
+      {{- end -}}
+      {{- $displayTitle = trim $displayTitle " "                 -}}
+    {{- end -}}
+
+    {{- with $Options.prefix -}}
+      {{- $prefix := $Options.prefix -}}
+
+      {{- if reflect.IsMap $prefix -}}
+        {{- $prefixes := slice -}}
+
+        {{- with $prefix.icon -}}
+          {{- $PrefixIcon := partialCached $RenderIcon (dict "Icon" $prefix.icon) $prefix.icon -}}
+          {{- $prefixes    = $prefixes | append $PrefixIcon                                    -}}
+        {{- end -}}
+
+        {{- with $prefix.markdown -}}
+          {{- with $LeadMatches := findRESubmatch $LeadingMarkupPattern $prefix.markdown -}}
+            {{- $Match    := index $LeadMatches 0                                 -}}
+            {{- $Lead     := index $Match       1                                 -}}
+            {{- $Markdown := index $Match       2                                 -}}
+            {{- $Rendered := printf "%s%s" $Lead ($Markdown | $Page.RenderString) -}}
+            {{- $prefixes  = $prefixes | append $Rendered                         -}}
+          {{- else -}}
+            {{- $prefixes = $prefixes | append ($prefix.markdown | $Page.RenderString) -}}
+          {{- end -}}
+        {{- end -}}
+
+        {{- $prefix = delimit $prefixes "&nbsp;" -}}
+      {{- else -}}
+        {{- $prefix = $prefix | $Page.RenderString -}}
+      {{- end -}}
+
+      {{- $displayTitle = printf "%s&nbsp;%s" $prefix $displayTitle -}}
+    {{- end -}}
+
+    {{- with $Options.suffix -}}
+      {{- $suffix := $Options.suffix -}}
+
+      {{- if reflect.IsMap $suffix -}}
+        {{- $suffixes := slice -}}
+
+        {{- with $suffix.markdown -}}
+          {{- with $LeadMatches := findRESubmatch $LeadingMarkupPattern $suffix.markdown -}}
+            {{- $Match    := index $LeadMatches 0                                 -}}
+            {{- $Lead     := index $Match       1                                 -}}
+            {{- $Markdown := index $Match       2                                 -}}
+            {{- $Rendered := printf "%s%s" $Lead ($Markdown | $Page.RenderString) -}}
+            {{- $suffixes  = $suffixes | append $Rendered                         -}}
+          {{- else -}}
+            {{- $suffixes = $suffixes | append ($suffix.markdown | $Page.RenderString) -}}
+          {{- end -}}
+        {{- end -}}
+
+        {{- with $suffix.icon -}}
+          {{- $SuffixIcon := partialCached $RenderIcon (dict "Icon" $suffix.icon) $suffix.icon -}}
+          {{- $suffixes    = $suffixes | append $SuffixIcon                                    -}}
+        {{- end -}}
+
+        {{- $suffix = delimit $suffixes "&nbsp;" -}}
+      {{- else -}}
+        {{- $suffix = $suffix | $Page.RenderString -}}
+      {{- end -}}
+
+      {{- $displayTitle = printf "%s %s" $displayTitle $suffix -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $displayTitle = $Options | $Page.RenderString -}}
+    {{- $displayTitle = trim $displayTitle " "        -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return ($displayTitle | safeHTML) -}}

--- a/modules/platen/layouts/partials/platen/utils/getMergedMap.html
+++ b/modules/platen/layouts/partials/platen/utils/getMergedMap.html
@@ -13,7 +13,7 @@
   {{- if reflect.IsMap $BaseValue -}}
     {{- with index $MergingMap $BaseKey -}}
       {{- $rContext := dict "MergingMap" . "BaseMap" $BaseValue "JoinArrays" $JoinArrays -}}
-      {{- $value     = partialCached "memo/utils/getMergedMap" $rContext $rContext       -}}
+      {{- $value     = partialCached "platen/utils/getMergedMap" $rContext $rContext     -}}
     {{- end -}}
   {{- else if (and (reflect.IsSlice $BaseValue) $JoinArrays) -}}
     {{- with index $MergingMap $BaseKey -}}

--- a/modules/platen/layouts/partials/platen/utils/getModule.html
+++ b/modules/platen/layouts/partials/platen/utils/getModule.html
@@ -1,9 +1,8 @@
-{{- $Context          := .                                                                  -}}
-{{- $IntegrityPartial := "platen/utils/getIntegrityAttributes"                              -}}
-{{- $ModuleSource     := "scripts/platen/module.js"                                         -}}
-{{- $ModuleDest       := "scripts/platen.js"                                                -}}
-{{- $moduleResource   :=  resources.Get $ModuleSource                                       -}}
-{{- $moduleResource    = $moduleResource | resources.ExecuteAsTemplate $ModuleDest $Context -}}
-{{- $moduleResource    = $moduleResource | resources.Fingerprint                            -}}
+{{- $IntegrityPartial := "platen/utils/getIntegrityAttributes"                          -}}
+{{- $ModuleSource     := "scripts/platen/module.js"                                     -}}
+{{- $ModuleDest       := "scripts/platen.js"                                            -}}
+{{- $moduleResource   := resources.Get $ModuleSource                                    -}}
+{{- $moduleResource    = $moduleResource | resources.ExecuteAsTemplate $ModuleDest page -}}
+{{- $moduleResource    = $moduleResource | resources.Fingerprint                        -}}
 {{/*  Return the resource  */}}
 {{- return $moduleResource -}}

--- a/modules/platen/layouts/partials/platen/utils/getTitle.html
+++ b/modules/platen/layouts/partials/platen/utils/getTitle.html
@@ -1,5 +1,49 @@
 {{/*
-  Partial to generate page name from Title or File name. Accepts Page as context
+  Utility Partial: getTitle
+
+  This partial generate's a page's title, handling features that might override
+  the title. It's context aware.
+
+  This partial expects to receive input that is either a page's context or a
+  dictionary with the following keys:
+
+  - Context: (Mandatory) The page context to retrieve the title for.
+  - ForHeader: (Optional) A boolean value indicating whether the title is being
+    called for use in the page's header. If it is, this value is `true`.
+  - ForHeading: (Optional) A boolean value indicating whether the title is
+    being called for use in a heading element. If it is, this value is `true`.
+  - ForHtmlHead: (Optional) A boolean value indicating whether the title is
+    being called for use in the page's HTML header's metadata. If it is, this
+    value is `true`.
+  - ForList: (Optional) A boolean value indicating whether the title is being
+    called for use in a list, like the `section` markup. If it is, this value
+    is `true`.
+  - ForMenu: (Optional) A boolean value indicating whether the title is being
+    called for use in the site menu. If it is, this value is `true`.
+
+  The `For*` parameters are all optional and default to not being set. This
+  allows anyone implementing a title partial from their feature to more
+  specifically control when they override the normal title.
+
+  This is necessary because the **first** resolved non-empty string for a title
+  is used. Platen's default handling is only used if no feature partial returns
+  a non-empty string for the title.
+
+  The default handler:
+
+  1. Uses $Context.LinkTitle over $Context.Title when ForMenu or ForList is
+     set to true. This allows an author to have their page title have a
+     different value in those contexts without any complex configuration.
+  1. If the title isn't being called for the site menu or a list, it uses
+     $Context.Title if it's defined.
+  1. If the page doesn't have $Context.Title defined, then:
+
+     1. If the page is a section, the title is the humanized/title case for the
+        folder name of the section page's Markdown source file.
+     1. If the page is a leaf, the title is the humanized/title case for the
+        file name of the leaf page's Markdown source file.
+  1. Finally, if the title isn't for the HTML Head, the title's text is
+     rendered from Markdown.
 */}}
 {{- $Params      := .                                                         -}}
 {{- $context     := .                                                         -}}
@@ -15,30 +59,34 @@
 
 {{- if reflect.IsMap $Params -}}
   {{- $context     = $Params.Context     -}}
-  {{- $forMenu     = $Params.ForMenu     -}}
   {{- $forHeader   = $Params.ForHeader   -}}
   {{- $forHeading  = $Params.ForHeading  -}}
   {{- $forHtmlHead = $Params.ForHtmlHead -}}
   {{- $forList     = $Params.ForList     -}}
+  {{- $forMenu     = $Params.ForMenu     -}}
 {{- end -}}
 
 {{- range $Feature, $Settings := $Features -}}
   {{- if and (eq "" $title) $Settings.enabled -}}
     {{- with $Settings.partials.title -}}
-      {{ $title = partial . $Params }}
+      {{ $title = partial $Settings.partials.title $Params }}
     {{- end -}}
   {{- end -}}
 {{- end -}}
 
 {{- if eq "" $title -}}
   {{- if and $context.LinkTitle (or $forMenu $forList) -}}
-    {{- $title = $context.LinkTitle | $context.RenderString -}}
+    {{- $title = $context.LinkTitle -}}
   {{- else if $context.Title -}}
     {{- $title = $context.Title -}}
   {{- else if and $context.IsSection $context.File -}}
     {{- $title = path.Base $context.File.Dir | humanize | title -}}
   {{- else if and $context.IsPage $context.File -}}
     {{- $title = $context.File.BaseFileName | humanize | title -}}
+  {{- end -}}
+
+  {{- if ne true $forHtmlHead -}}
+    {{- $title = $title | $context.RenderString -}}
   {{- end -}}
 {{- end -}}
 

--- a/modules/platen/layouts/partials/platen/utils/jsonify.html
+++ b/modules/platen/layouts/partials/platen/utils/jsonify.html
@@ -1,0 +1,22 @@
+{{/*  
+    Utility Partial: jsonify
+
+    This utility partial is a somewhat friendly wrapper for use when debugging
+    or displaying JSON info. It just calls jsonify on the input but always sets
+    the indent and noHTMLEscape options.
+
+    Use when debugging to turn calls like this:
+
+        {{- warnf "Result is: %s" (
+              $Result | jsonify (dict "indent" "  " "noHTMLEscape" true)
+            )
+        -}}
+
+    Into this:
+
+    {{- warnf "Result is: %s" (partial "platen/utils/jsonify" $Result) -}}
+*/}}
+{{- $Input   := .                                      -}}
+{{- $Options := dict "indent" "  " "noHTMLEscape" true -}}
+
+{{- return ($Input | jsonify $Options) -}}

--- a/modules/platen/layouts/partials/platen/utils/shouldRenderToC.html
+++ b/modules/platen/layouts/partials/platen/utils/shouldRenderToC.html
@@ -1,0 +1,51 @@
+{{/*
+    Utility Partial: shouldRenderToC
+
+    Determines whether the table of contents should be rendered for the page.
+
+    This partial expects no input and always operates on the current page.
+
+    It uses the settings from `platen.display.table_of_contents` in the site
+    configuration and the `platen.table_of_contents` options in the page's
+    front matter to determine whether the TOC should try to render at all.
+
+    If it should, the partial then uses the settings for minimum and maximum
+    heading levels to render for the TOC to see whether there are enough
+    headings in the page content (minimum 2) to be worth rendering the TOC.
+
+    If the `render` setting is `true` and the page has at least two headings
+    whose level is in the valid range, this partial returns `true`. Otherwise,
+    it returns `false`.
+
+    This partial should always be called with `partialCached`, like this:
+
+        partialCached "platen/utils/shouldRenderToC" page page
+
+    That ensures the call is cached for the current page, since it gets called
+    at least twice in the baseof template.
+*/}}
+{{- $PageContent   := page.Content                                                        -}}
+{{- $ConfigKey     := "platen.display.table_of_contents"                                  -}}
+{{- $SiteConfigToC := partialCached "platen/param/getKey" $ConfigKey $ConfigKey           -}}
+{{- $PageConfigToC := page.Params.platen.table_of_contents                                -}}
+{{- $MergeParams   := dict "BaseMap" $SiteConfigToC "MergingMap" $PageConfigToC           -}}
+{{- $MergedConfig  := partialCached "platen/utils/getMergedMap" $MergeParams $MergeParams -}}
+{{- $RenderSetting := $MergedConfig.render | default true                                 -}}
+{{- $MinLevel      := $MergedConfig.minimum_level | default 2                             -}}
+{{- $MaxLevel      := $MergedConfig.maximum_level | default 4                             -}}
+
+{{/* Build Regex to find includable headings. */}}
+{{- $Pattern := delimit (
+      slice
+      (printf "<h[%v-%v].*?>" $MinLevel $MaxLevel)
+      "(.|\n)+?"
+      (printf "</h[%v-%v]>"   $MinLevel $MaxLevel)
+    ) "" | print
+-}}
+
+{{/* Find all headings in the rendered content */}}
+{{- $Headers      := findRE $Pattern $PageContent   -}}
+{{- $HasHeaders   := ge (len $Headers) 1            -}}
+{{- $ShouldRender := and $RenderSetting $HasHeaders -}}
+
+{{- return $ShouldRender -}}

--- a/modules/platen/layouts/partials/platen/utils/styles/fonts.html
+++ b/modules/platen/layouts/partials/platen/utils/styles/fonts.html
@@ -75,6 +75,20 @@
   {{/* Close the selector and delimit it with appropriate indentation for rendering */}}
   {{- $selectorString = $selectorString | append "}"                                   -}}
   {{- $renderStrings  = $renderStrings  | append (delimit $selectorString "\n  " "\n") -}}
+
+  {{/*  Temporary special handling for body to conform with Shoelace  */}}
+  {{- if and (eq $Name "body") (isset $Settings "family") -}}
+    {{- $sansFontOverride := printf `--sl-font-sans: %s;` $Settings.family  -}}
+    {{- $sansFontOverride  = printf ":root {\n  %s\n}"    $sansFontOverride -}}
+    {{- $renderStrings     = $renderStrings | append      $sansFontOverride -}}
+  {{- end -}}
+
+  {{/*  Temporary special handling for code to conform with Shoelace.  */}}
+  {{- if and (eq $Name "code") (isset $Settings "family") -}}
+    {{- $monoFontOverride := printf `--sl-font-mono: %s;` $Settings.family  -}}
+    {{- $monoFontOverride  = printf ":root {\n  %s\n}"    $monoFontOverride -}}
+    {{- $renderStrings     = $renderStrings | append      $monoFontOverride -}}
+  {{- end -}}
 {{ end }}
 
 {{/* Return the SCSS to render */}}

--- a/modules/schematize/assets/styles/shortcodes/_schematize.scss
+++ b/modules/schematize/assets/styles/shortcodes/_schematize.scss
@@ -54,13 +54,16 @@ section.schematize {
         div.schematize-metadata-definition-group.inline {
           display: flex;
           flex-direction: row;
+          flex-wrap: wrap;
           justify-content: flex-start;
           dd:has(code.schematize-enum) {
             width: max-content;
-            &::before {
-              content: ", ";
+            padding-inline-start: 1em;
+            padding-inline-end: 1em;
+            &::after {
+              content: "";
             }
-            &:first-of-type::before{
+            &:last-of-type::after{
               content: "";
             }
           }

--- a/modules/toroidal/layouts/partials/toroidal/admin.html
+++ b/modules/toroidal/layouts/partials/toroidal/admin.html
@@ -10,6 +10,7 @@
         dict "Config"  "toroidal.class"
              "Param"   "toroidal_class"
              "Context" $Context
+             "Default" ""
       )
   -}}
 {{- else -}}


### PR DESCRIPTION
This change started as an improved integration with Shoelace's icons. It now represents an overhauled integration with Shoelace and starts down the path of ensuring a consistent UI and improving the configurability and theming for the site components as well as a consistent DevX for markup.

In particular, after this update, Platen supports twelve different icon libraries by default and provides a shorthand syntax for users to specify an icon as a string:

```
<name>[&<variant>][@library]
```

Only `name` is required in the shorthand syntax. This makes it simpler to specify variant icons from alternate libraries even in attribute-only markup, and obviates needing multiple attributes for a single icon option.

This change reimplements the site's table of contents to use Shoelace's tree component, making the TOC collapsible by default. All site components that previously used static SVGs are now configurable Shoelace icons and where sensible the components have tooltips.

The markup for alerts, buttons, and details is also updated to support icon variants and libraries.

This change also introduces a warning about using legacy components and directs site maintainers to a new document explaining the features and how to opt into them before the legacy implementations are removed.

This change still requires documentation.