### PR TITLE
(MAINT) Add rolling prototype and fixes

### DIFF
--- a/modules/platen/assets/scripts/markup/rolls/rolling.js
+++ b/modules/platen/assets/scripts/markup/rolls/rolling.js
@@ -1,0 +1,272 @@
+let Roller = new rpgDiceRoller.DiceRoller();
+
+function randomItem(collection) {
+    return collection[Math.floor(Math.random() * collection.length)];
+}
+
+function resultReference(index) {
+    return `result_${index}`
+}
+
+function escapeRegExp(string) {
+    // $& means the whole matched string
+    return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function getResultText(roll, result, template) {
+    let pattern = /\{\{\s*(?<variable>(?:\w|\.)+)\s*\}\}/g
+    let matches = template.matchAll(pattern)
+    let resultText = template
+    for (const match of matches) {
+        let stringToReplace = match[0]
+        let varName = match.groups.variable
+        let replacementValue = result
+        if (varName == 'roll') {
+            replacementValue = `${roll}`
+        } else {
+            varName.split('.').forEach(function (dotSegment) {
+                replacementValue = replacementValue[dotSegment]
+            })
+        }
+
+        resultText = resultText.replace(stringToReplace, replacementValue)
+    }
+
+    return resultText
+}
+
+function rollNotation(data, container, notation) {
+    let rolls          = []
+    let prompts        = container.querySelectorAll('sl-input')
+    let mungedNotation = notation
+
+    if (prompts.length > 0) {
+        prompts.forEach(prompt => {
+            mungedNotation = mungedNotation.replace(`{{ ${prompt.name} }}`, `${prompt.value}`)
+        })
+    }
+
+    mungedNotation.split(',').forEach(function (statement) {
+        let roll = Roller.roll(statement)
+        rolls.push(roll.total)
+    })
+
+    return rolls
+}
+
+function rollInline(data, refs, id) {
+    let container = refs[id]
+    let result = rollNotation(data, container, data.roll)
+    
+    console.log(result)
+    data.result = result
+
+    let result_sum = 0
+    result.forEach(r => result_sum += r)
+
+    if (data.result_text_template != '') {
+        let text = data.result_text_template.replace('{{ result }}', result)
+        text = text.replace('{{ result.sum }}', result_sum )
+        data.result_text = text
+    } else {
+        data.result_text = result_sum
+    }
+}
+
+function sortResultsInfo(results) {
+    let sorted = []
+    results.forEach(result => {
+        let sortKey = getSortableInfo(result._roll)
+        let sortable = JSON.parse(`{"${sortKey}": ${JSON.stringify(result)}}`)
+        result.sortable = sortKey
+        sorted.push(result)
+    })
+
+    sorted.sort((a, b) => {
+        if (a.sortable > b.sortable) {
+            return 1
+        }
+        if (a.sortable < b.sortable) {
+            return -1
+        }
+        return 0
+    })
+
+    return sorted
+}
+
+function getSortableInfo(info) {
+    let min = undefined
+    let max = undefined
+
+    if (info.hasOwnProperty('Value')) {
+        if (Array.isArray(info.Value)) {
+            let munged = []
+            info.Value.forEach(value => {
+                munged.push(String(value).padStart(4, '0'))
+            })
+            munged = munged.join('')
+            min = munged
+            max = munged
+            return [min, max]
+        } else {
+            munged = String(info.Value).padStart(4,'0')
+            min = munged
+            max = munged
+            return [min, max]
+        }
+    }
+
+    if (info.hasOwnProperty('Minimum')) {
+        min = String(info.Minimum).padStart(4, '0')
+    }
+    if (info.hasOwnProperty('ExclusiveMinimum')) {
+        min = String(info.ExclusiveMinimum + 1).padStart(4, '0')
+    }
+    if (info.hasOwnProperty('Maximum')) {
+        max = String(info.Maximum).padStart(4, '0')
+    }
+    if (info.hasOwnProperty('ExclusiveMaximum')) {
+        max = String(info.ExclusiveMaximum - 1).padStart(4, '0')
+    }
+
+    return [min, max]
+}
+
+function rollOn(data, refs, id) {
+    let container = refs[id]
+    let entries   = container.querySelectorAll('[data-roll]')
+
+    let result = rollNotation(data, container, data.roll)
+    let entry  = getRolledItem(result, entries)
+
+    entries.forEach(entry => {
+        entry.dataset.active = false
+    })
+
+    entry.dataset.active = true
+    entry.focus = true
+
+    if (data?.tabs?.length > 0) {
+        let tabs   = container.querySelectorAll('sl-tab')
+        let panels = container.querySelectorAll('sl-tab-panel')
+        
+        panels.forEach(panel => {
+            panel.active = false
+        })
+        let panel = entry.closest('sl-tab-panel')
+
+        tabs.forEach(tab => {
+            tab.active = (tab.name == panel.name)
+        })
+
+        panel.active = true
+    }
+
+    let entryDisplay    = JSON.parse(entry.dataset.roll).Display
+    let dataResultIndex = Object.keys(data.results).find(index => {
+        dataDisplay = data.results[index]._roll.Display
+        return dataDisplay == entryDisplay
+    })
+    let dataResult = data.results[dataResultIndex]
+
+    let displayResult = result
+
+    if (data.result_text_template != '') {
+        let resultText = getResultText(
+            displayResult,
+            dataResult,
+            data.result_text_template
+        )
+        data.result_text = resultText
+    }
+
+    if (data.prompts.length > 0) {
+        container.querySelector('sl-dialog').hide()
+    }
+}
+
+function getRolledItem(roll, entries) {
+    // implies a d33, d66, d666, etc
+    rollIsArray = Array.isArray(roll)
+    // Loop over each entry til we find a match.
+    for (const entry of entries) {
+        // Parse the entry's data
+        info = JSON.parse(entry.dataset.roll)
+        // Retrieve the list of conditions that makes this entry a possible match.
+        conditions = Object.keys(info)
+
+        // Handle multi-dimensional results, like 3-2 on a d66
+        if (rollIsArray && Array.isArray(info.Value)) {
+            let isRolledEntry = true
+            for (die in roll) {
+                if (roll[die] != info.Value[die]) {
+                    isRolledEntry = false
+                    break
+                }
+            }
+            if (isRolledEntry) {
+                return entry
+            }
+        }
+
+        // Handle single-dimensional results, like 4 on a d20
+        if (conditions.includes('Value')) {
+            if (roll == info.Value) {
+                return entry
+            }
+            continue
+        }
+
+        // If we couldn't do an exact match, we need to do a conditional on the minimum/maximums
+        // Start with the entry being valid and go through applicable checks, marking it invalid
+        // if any check fails.
+        let isValid = true
+        if (conditions.includes('Minimum') && roll < info.Minimum) {
+            isValid = false
+        }
+        if (conditions.includes('ExclusiveMinimum') && roll <= info.ExclusiveMinimum) {
+            isValid = false
+        }
+        if (conditions.includes('Maximum') && roll > info.Maximum) {
+            isValid = false
+        }
+        if (conditions.includes('ExclusiveMaximum') && roll >= info.ExclusiveMaximum) {
+            isValid = false
+        }
+        if (isValid) {
+            return entry
+        }
+    }
+}
+
+function decodeHTML(input) {
+    var e = document.createElement('textarea');
+    e.innerHTML = input;
+    // handle case of empty input
+    return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+}
+
+function filterResults(results, validResults) {
+    let valid = []
+
+    results.forEach(result => {
+        if (validResults.includes(result._roll.Display)) {
+            valid.push(result)
+        }
+    })
+
+    return valid
+}
+
+function showPrompts(data, refs, id) {
+    let dialog = refs[id].querySelector('sl-dialog')
+    dialog.querySelectorAll('sl-input').forEach(input => input.setAttribute('value', ''))
+    dialog.show()
+}
+
+function definePrompt(element, prompt) {
+    for (const key of Object.keys(prompt)) {
+        element.setAttribute(key, prompt[key])
+    }
+}

--- a/modules/platen/assets/styles/markdown/_tables.scss
+++ b/modules/platen/assets/styles/markdown/_tables.scss
@@ -18,3 +18,44 @@
     }
   }
 }
+
+.markdown table.sticky {
+  width: max-content;
+  height: 22rem;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  table-layout: fixed;
+  margin: auto;
+  @include outline;
+
+  thead {
+    width: 100%;
+    background: var(--body-background);
+    position: sticky;
+    inset-block-start: 0;
+
+    /* "top" */
+    tr {
+      width: 100%;
+
+      th:nth-child(odd) {
+        width: 75%;
+      }
+
+      th:nth-child(even) {
+        width: 25%;
+      }
+    }
+  }
+
+  tbody {
+    width: 100%;
+  }
+
+  &::-webkit-scrollbar {
+    width: 10px;
+    /* Mostly for vertical scrollbars */
+    height: 10px;
+    /* Mostly for horizontal scrollbars */
+  }
+}

--- a/modules/platen/assets/styles/markup/_columns.scss
+++ b/modules/platen/assets/styles/markup/_columns.scss
@@ -19,3 +19,31 @@
     }
   }
 }
+
+// For arbitrary columns as attributes on a block of text
+.markdown {
+  ul.columns,
+  ol.columns {
+    -moz-column-count: 2;
+    -moz-column-gap: 2rem;
+    -moz-column-width: 8em;
+    -webkit-column-count: 2;
+    -webkit-column-gap: 2rem;
+    -webkit-column-width: 8em;
+    column-count: 2;
+    column-gap: 2rem;
+    column-width: 8em;
+
+    &.count-3 {
+      -moz-column-count: 3;
+      -webkit-column-count: 3;
+      column-count: 3;
+    }
+
+    &.count-4 {
+      -moz-column-count: 4;
+      -webkit-column-count: 4;
+      column-count: 4;
+    }
+  }
+}

--- a/modules/platen/assets/styles/markup/_rolls.scss
+++ b/modules/platen/assets/styles/markup/_rolls.scss
@@ -1,0 +1,65 @@
+.markdown span.inline-roll {
+  sl-button[variant="text"] {
+    &::part(label) {
+      padding-left: 0;
+      padding-right: 0;
+      font-size: inherit;
+      font-family: inherit;
+    }
+  }
+}
+
+.markdown div.platen-roll-table {
+  // targets the list itself
+  --rolled-item-color: var(--sl-color-primary-700);
+  --rolled-item-weight: bolder;
+  contain: layout;
+  table {
+    height: 100%;
+    // general list items
+    tr {
+      // rolled item
+      &[data-active="true"] {
+        color: var(--rolled-item-color);
+        font-weight: var(--rolled-item-weight);
+      }
+    }
+  }
+  span.result-text {
+    margin-inline-start: $padding-large;
+  }
+  sl-dialog {
+    &::part(base) {
+      // top: 50%;
+      // left: 50%;
+      // inset: unset;
+    }
+  }
+}
+
+.markdown div.platen-roll-list {
+  // targets the list itself
+  --rolled-item-color: var(--sl-color-primary-700);
+  --rolled-item-weight: bolder;
+  ol {
+    // general list items
+    li {
+      // rolled item
+      &[data-active="true"] {
+        color: var(--rolled-item-color);
+        font-weight: var(--rolled-item-weight);
+        ::marker {
+          color: var(--rolled-item-color);
+          font-weight: var(--rolled-item-weight);
+        }
+      }
+      // list-style: none;
+      &::marker {
+        content: attr(data-list-content);
+      }
+    }
+  }
+  span.result-text {
+    margin-inline-start: $padding-large;
+  }
+}

--- a/modules/platen/config/_default/params.yaml
+++ b/modules/platen/config/_default/params.yaml
@@ -465,6 +465,14 @@ platen:
         header: platen/markup/mermaid/header
         renderers:
           codeblock: platen/markup/mermaid/codeblock
+    rolls:
+      enabled: true
+      partials:
+        renderers:
+          codeblock: platen/markup/rolls/codeblock
+          image:     platen/markup/rolls/image
+        header: platen/markup/rolls/header
+      style: rolls
     section:
       enabled: true
       partials:

--- a/modules/platen/data/platen/rolls/inline/_default.yaml
+++ b/modules/platen/data/platen/rolls/inline/_default.yaml
@@ -1,0 +1,7 @@
+button:
+  pill: true
+  variant: text
+  outline: true
+tooltip:
+  placement: top
+result_text_template: "Rolled: {{ result.sum }}. Click to roll again."

--- a/modules/platen/data/platen/rolls/lists/_default.yaml
+++ b/modules/platen/data/platen/rolls/lists/_default.yaml
@@ -1,0 +1,6 @@
+columns: 1
+button:
+  pill: true
+  variant: primary
+  placement: below
+  label: Roll on the list

--- a/modules/platen/data/platen/rolls/tables/_default.yaml
+++ b/modules/platen/data/platen/rolls/tables/_default.yaml
@@ -1,0 +1,5 @@
+button:
+  pill: true
+  variant: primary
+  placement: below
+  label: Roll on the table

--- a/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_block.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_block.html
@@ -1,0 +1,127 @@
+{{- $Params     := .                  -}}
+{{- $Config     := $Params.Config     -}} {{/* The markup's site configuration, like platen.markup.foo     */}}
+{{- $Position   := $Params.Position   -}} {{/* The markup's position in the Markdown - only for codeblocks */}}
+{{- $Page       := $Params.Page       -}} {{/* The Page object for the Markdown document the markup is in  */}}
+{{- $ValidIDs   := $Params.ValidIDs   -}} {{/* The map or slice of valid IDs for the markup                */}}
+{{- $ID         := $Params.ID         -}} {{/* The used language ID (codeblock) or prefix (image/link)     */}}
+{{- $Definition := $Params.Definition -}} {{/* The non-yaml text of the markup - only for codeblocks       */}}
+{{- $options    := $Params.Options    -}} {{/* The pre-merged options, attributes, and preset properties   */}}
+
+{{/*  Platen utility partials  */}}
+{{- $mungeHeadingLevel    := "platen/utils/mungeHeadingLevel"    -}}
+{{- $getLeadTrimmedText   := "platen/utils/getLeadTrimmedText"   -}}
+{{- $getMergedClasses     := "platen/utils/getMergedClasses"     -}}
+{{- $getMergedMap         := "platen/utils/getMergedMap"         -}}
+{{- $getMergedStyleOption := "platen/utils/getMergedStyleOption" -}}
+{{- $getPrettyRender      := "platen/utils/getPrettyRender"      -}}
+{{- $getSafeAttributes    := "platen/utils/getSafeAttributes"    -}}
+{{/*  Roll-specific utility partials  */}}
+{{- $normalizeButtonInfo         := "platen/markup/rolls/utils/_normalizeButtonInfo"         -}}
+{{- $normalizePromptInfo         := "platen/markup/rolls/utils/_normalizePromptInfo"         -}}
+{{- $normalizeRollInfo           := "platen/markup/rolls/utils/_normalizeRollInfo"           -}}
+{{- $normalizeResultTextTemplate := "platen/markup/rolls/utils/_normalizeResultTextTemplate" -}}
+{{- $normalizeSimpleResults      := "platen/markup/rolls/utils/_normalizeSimpleResults"      -}}
+{{- $getIDs                      := "platen/markup/rolls/utils/_getIDs"                      -}}
+
+{{/*
+      Determine the kind of block. Lists are simpler than tables. Some of their
+      settings are shared, but not all. Split the ID on the dash to infer or
+      just default to table.
+*/}}
+{{- $Kind              := index (last 1 (split $ID "-")) 0 | default "table" -}}
+{{- $configOptions     := slice                                                -}}
+{{- $nonConfigDefaults := dict                                                 -}}
+
+{{- if eq $Kind "table" -}}
+  {{/*  Add table-specific options and defaults  */}}
+{{- else if (eq $Kind "list") -}}
+  {{/*  Add list-specific options and defaults  */}}
+{{- else -}}
+  {{- errorf "Unknown roll kind '%s' at %s" $Kind $Position -}}
+{{- end -}}
+
+{{- range $OptionKey := $configOptions -}}
+  {{- if isset $Config $OptionKey -}}
+    {{- $ConfigValue := index $Config  $OptionKey                        -}}
+    {{- $Value       := index $options $OptionKey | default $ConfigValue -}}
+    {{- $options      = merge $options (dict $OptionKey $Value)          -}}
+  {{- else if (in $OptionKey ".") -}}
+    {{- $key   := replace $OptionKey "." "_" -}}
+    {{- $value := $Config                    -}}
+    {{- range $Segment := split $OptionKey "." -}}
+      {{- $value = index $value $Segment -}}
+    {{- end -}}
+    {{- if ne nil $value -}}
+      {{- $value   = index $options $key | default $value -}}
+      {{- $options = merge $options (dict $key $value)    -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- range $Key, $Value := $nonConfigDefaults -}}
+  {{- if not (isset $options $Key) -}}
+    {{- $options = merge $options (dict $Key $Value) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  Define the template folder and default template for this markup  */}}
+{{- $TemplateFolder := "platen/markup/rolls/templates" -}}
+{{- $template       := printf "%ss/default" $Kind      -}}
+
+{{/*  Initialize the return value for this partial  */}}
+{{- $canonical := dict -}}
+
+{{- $KindCanonicalizer := printf "platen/markup/rolls/canonicalize/_%s"   $Kind     -}}
+{{- $KindParams        := dict "Options" $options "Page" $Page "Position" $Position -}}
+{{- $KindCanonicalized := partial $KindCanonicalizer     $KindParams                -}}
+{{- $canonical          = merge   $canonical             $KindCanonicalized         -}}
+
+{{/*  Handle the id and x-ref attributes  */}}
+{{- $IDs      := partial $getIDs (dict "Options" $options) -}}
+{{- $canonical = merge $canonical $IDs                     -}}
+
+{{/*  Canonicalize container classes  */}}
+{{- $DefaultClasses := slice (printf "platen-roll-%s" $Kind)                      -}}
+{{- $MergingParams  := dict "Default" $DefaultClasses "Additional" $options.class -}}
+{{- $Classes        := partial $getMergedClasses $MergingParams                   -}}
+{{- $canonical       = merge $canonical (dict "Classes" $Classes)                 -}}
+
+{{/*  Handle prompts  */}}
+{{- $PromptParams := dict "Canonical" $canonical "Options" $options -}}
+{{- $PromptInfo   := partial $normalizePromptInfo $PromptParams     -}}
+{{- $canonical     = merge $canonical $PromptInfo                   -}}
+
+{{/*  Handle the button settings.  */}}
+{{- $ButtonParams := dict "Options" $options "Page" $Page       -}}
+{{- $ButtonInfo   := partial $normalizeButtonInfo $ButtonParams -}}
+{{- $canonical     = merge $canonical $ButtonInfo               -}}
+
+{{/*  Ensure required libraries are added  */}}
+{{- $Params.Page.Store.Set "_hasRolls"    true -}}
+{{- $Params.Page.Store.Set "_hasShoelace" true -}}
+{{- $Params.Page.Store.Set "_hasAlpine"   true -}}
+
+{{- if $options.custom -}}
+  {{- $canonical = merge $canonical (dict "Page"     $Page)     -}}
+  {{- $canonical = merge $canonical (dict "Position" $Position) -}}
+  {{- $canonical = merge $canonical (dict "Config"   $Config)   -}}
+  {{- $canonical = merge $canonical (dict "Options"  $options)  -}}
+  {{/*
+      Set the render template; this assumes that the markup provides a default
+      custom template that users can copy and override. If the user specified a
+      value other than `true`, that's assumed to be the name of the template
+      in `partials/platen/markup/NAME/templates`.
+  */}}
+  {{- if eq true $options.custom -}}
+    {{- $template = "custom" -}}
+  {{- else -}}
+    {{- $template = $options.custom -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  As the last step, add the canonicalized template to render  */}}
+{{- $template  = printf "%s/%s" $TemplateFolder $template     -}}
+{{- $canonical = merge $canonical (dict "Template" $template) -}}
+
+{{/*  Return the canonicalized values to the markup for rendering  */}}
+{{- return $canonical -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_inline.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_inline.html
@@ -1,0 +1,259 @@
+{{- $Params     := .                  -}}
+{{- $Config     := $Params.Config     -}} {{/* The markup's site configuration, like platen.markup.foo     */}}
+{{- $Position   := $Params.Position   -}} {{/* The markup's position in the Markdown - only for codeblocks */}}
+{{- $Page       := $Params.Page       -}} {{/* The Page object for the Markdown document the markup is in  */}}
+{{- $ValidIDs   := $Params.ValidIDs   -}} {{/* The map or slice of valid IDs for the markup                */}}
+{{- $ID         := $Params.ID         -}} {{/* The used language ID (codeblock) or prefix (image/link)     */}}
+{{- $Kind       := $Params.Kind       -}} {{/* The kind of markup: codeblock, image, link, etc             */}}
+{{- $Definition := $Params.Definition -}} {{/* The non-yaml text of the markup - only for codeblocks       */}}
+{{- $options    := $Params.Options    -}} {{/* The pre-merged options, attributes, and preset properties   */}}
+
+{{/*
+    Define partials for easier calling/renaming. If there's any that you don't
+    need, you can delete them or leave them here.
+
+    - mungeHeadingLevel converts a value for a heading level to between 0 and 6,
+      inclusive. A value of 0 indicates that the markup shouldn't be rendered
+      as a heading. If the value is less than 0, it's munged to 0. If it's
+      greater than 6, it's munged to 6.
+
+    - getLeadTrimmedText takes a block of text and trims the leading whitespace
+      for the first line from the remaining lines. Use this to ensure Markdown
+      in a nested codeblock can be rendered correctly.
+
+    - getMergedClasses merges one or more default classes with a list of
+      additional classes, returning the union of the two lists (no duplicate
+      values). It's space-delimited by default, but you can pass Delimit as false
+      to return the values as a slice.
+
+    - getPrettyRender renders a line or block of Markdown and munges it for line
+      length and indentation. You can use the AsBlock option in the parameters
+      to always render the Markdown as a block, even when it's only one line.
+      You can set the indent count with the IndentCount option.
+
+    - getSafeAttributes takes a slice of HTML element attributes as strings and
+      returns them as a single space-delimited string, marked as safe for
+      insertion into HTML attributes.
+*/}}
+{{- $mungeHeadingLevel    := "platen/utils/mungeHeadingLevel"    -}}
+{{- $getLeadTrimmedText   := "platen/utils/getLeadTrimmedText"   -}}
+{{- $getMergedClasses     := "platen/utils/getMergedClasses"     -}}
+{{- $getMergedMap         := "platen/utils/getMergedMap"         -}}
+{{- $getMergedStyleOption := "platen/utils/getMergedStyleOption" -}}
+{{- $getPrettyRender      := "platen/utils/getPrettyRender"      -}}
+{{- $getSafeAttributes    := "platen/utils/getSafeAttributes"    -}}
+{{/*  Define the template folder and default template for this markup  */}}
+{{- $TemplateFolder := "platen/markup/rolls/templates/inline" -}}
+{{- $template       := "default"                      -}}
+{{/*
+    Define the list of valid config options that can be used as defaults for
+    the markup when not supplied directly or by a preset. Delete this section
+    if the markup doesn't use defaults from the site config.
+
+    You can specify values with dotpath notation as needed, but they should
+    always be relative to the markup's configuration key. So far the config
+    setting 'platen.markup.foo.bar.baz', specify the key as "foo.bar.baz"
+*/}}
+{{- $ConfigOptions := slice -}}
+{{/*
+    Define the list of default values for the options that aren't pulled from
+    the site configuration. Delete this section if you don't need it.
+
+    If you need to define defaults, add them to the dictionary using the
+    option's key and default value. For example, to default the legacy option
+    to false, add this to the $NonConfigDefaults dictionary:
+
+        "legacy" false
+*/}}
+{{- $NonConfigDefaults := dict -}}
+{{/*  Initialize the return value for this partial  */}}
+{{- $canonical := dict -}}
+
+{{/*
+    Canonicalize options with config defaults, using the value from the config
+    unless specified by the markup options (already merged with preset).
+
+    Delete this section if the markup doesn't use defaults from the site config.
+
+    It loops over the list of config options to see if they're set. Then it uses
+    those values as the default for the matching value from the merged options,
+    ignoring the value from config if it was set in the markup's attribute,
+    options, or preset properties.
+
+    You can check the name of the key to do specific munging if the values in
+    the configuration don't match the value type for the options. Here we left
+    the handling for classes, where the configuration specifies `classes` as an
+    array but markup always uses `class` due to the built-in handling of class
+    attributes by Hugo. It space-delimits the values from config and uses them
+    as a default if `class` isn't defined in the options.
+
+    You can do similar handling for other keys by adding an 'else if' statement
+    before the end of the conditional, like:
+
+        {{- else if (eq "use_legacy" $OptionKey) -}}
+          {{- $key   = "legacy"                         -}}
+          {{- $value = $options.legacy | default $value -}}
+        {{- else -}}
+
+    Which would check for a key called 'use_legacy' and use its value for the
+    'legacy' key in the options.
+*/}}
+{{- range $OptionKey := $ConfigOptions -}}
+  {{- if isset $Config $OptionKey -}}
+    {{- $key   := $OptionKey               -}}
+    {{- $value := index $Config $OptionKey -}}
+    {{- if eq "classes" $OptionKey -}}
+      {{- $key   = "class"                         -}}
+      {{- $value = $options.class | default (delimit $value " ") -}}
+    {{- else -}}
+      {{- $value = index $options $OptionKey | default $value -}}
+    {{- end -}}
+    {{/*  Merge the munged value in  */}}
+    {{- $options = merge $options (dict $key $value) -}}
+  {{- else if (in $OptionKey ".") -}}
+    {{/*
+        This section is for config options that aren't at the top level. We
+        default to using the path, replacing the dots with underscores, as
+        the key name. So `foo.bar.baz` becomes `foo_bar_baz`.
+
+        If your markup doesn't have any config items that are nested and need
+        to be accessed with the dot path, you can delete this conditional block.
+
+        As with the top-level keys, you can add handling for specific keys by
+        checking the key name and munging either or both the key and value to
+        insert into the options.
+    */}}
+    {{- $key   := replace $OptionKey "." "_" -}}
+    {{/*  Retrieve the value from the config if defined  */}}
+    {{- $value := $Config                    -}}
+    {{- range $Segment := split $OptionKey "." -}}
+      {{- $value = index $value $Segment -}}
+    {{- end -}}
+    {{/*  If the value was defined, process it for merging  */}}
+    {{- if ne nil $value -}}
+      {{/*
+          Add handling for specific keys here, like:
+
+              {{- if eq "icons.collapse" $OptionKey -}}
+                {{- $key = "icon_collapse" -}}
+              {{- else if (eq "icons.expand" $OptionKey) -}}
+                {{- $key = "icon_expand" -}}
+              {{- end -}}
+      */}}
+      {{/*  Merge the config value over the options if not set explicitly  */}}
+      {{- $value   = index $options $key | default $value -}}
+      {{- $options = merge $options (dict $key $value)    -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+    Loop over the default values that aren't defined by the configuration and
+    set if needed.
+
+    You can delete this section if your markup doesn't support default values
+    for the options that aren't sourced from the configuration.
+*/}}
+{{- range $Key, $Value := $NonConfigDefaults -}}
+  {{- if not (isset $options $Key) -}}
+    {{- $options = merge $options (dict $Key $Value) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+    This canonicalizes a list of classes, merging the markup's default(s) with
+    those specified in the options.
+
+    You can delete this section if your template doesn't need this, or reuse
+    this pattern if you need to get class lists for more than one element.
+*/}}
+{{- $DefaultClasses := slice "inline-roll"                                        -}}
+{{- $MergingParams  := dict "Default" $DefaultClasses "Additional" $options.class -}}
+{{- $Classes        := partial $getMergedClasses $MergingParams                   -}}
+{{- $canonical       = merge $canonical (dict "Classes" $Classes)                 -}}
+
+{{- with $roll := $options.roll -}}
+  {{- with $options.results -}}
+  {{- else -}}
+    {{/*  Simple roll  */}}
+    {{- $canonical = merge $canonical (dict "Roll" $roll) -}}
+  {{- end -}}
+  {{- $label := $options.label | default $roll -}}
+  {{- $canonical = merge $canonical (dict "Label" $label) -}}
+{{- else -}}
+  {{ errorf "Missing roll notation for inline roll on '%s'" $Page -}}
+{{- end -}}
+
+{{- with $ResultTextTemplate := $options.result_text_template -}}
+  {{- $canonical = merge $canonical (dict "ResultTextTemplate" $ResultTextTemplate) -}}
+{{- end -}}
+
+{{- with $Button := $options.button -}}
+  {{- $attributes := slice -}}
+  {{- if $Button.pill -}}
+    {{- $attributes = $attributes | append `pill` -}}
+  {{- end -}}
+  {{- if $Button.outline -}}
+    {{- $attributes = $attributes | append `outline` -}}
+  {{- end -}}
+  {{- with $Button.size -}}
+    {{- $attributes = $attributes | append (printf `size="%s"` $Button.size) -}}
+  {{- end -}}
+  {{- with $Button.variant -}}
+    {{- $attributes = $attributes | append (printf `variant="%s"` $Button.variant) -}}
+  {{- end -}}
+  {{- $attributes = partial $getSafeAttributes $attributes                 -}}
+  {{- $canonical  = merge $canonical (dict "ButtonAttributes" $attributes) -}}
+{{- end -}}
+
+{{- with $Tooltip := $options.tooltip -}}
+  {{- $attributes := slice -}}
+  {{- with $Tooltip.placement -}}
+  {{- $attributes = $attributes | append (printf `placement="%s"` $Tooltip.placement) -}}
+  {{- end -}}
+  {{- $attributes = partial $getSafeAttributes $attributes                  -}}
+  {{- $canonical  = merge $canonical (dict "TooltipAttributes" $attributes) -}}
+{{- end -}}
+
+{{/*
+    This builds a list of attributes and turns them into an insertable list for
+    your template. Make sure you actually handle the attributes that need to be
+    inserted, this is just an example. You can also pass the attribute values
+    directly into the canonical map to insert in the template.
+
+    Note that we're always appending the full attribute declaration, including
+    name and value, as a string to the list of attributes.
+*/}}
+{{- $attributes := slice -}}
+{{- with $Classes -}}
+  {{- $attributes = $attributes | append (printf `class="%s"` $Classes) -}}
+{{- end -}}
+
+{{- $attributes = partial $getSafeAttributes $attributes           -}}
+{{- $canonical  = merge $canonical (dict "Attributes" $attributes) -}}
+
+{{/*  Ensure required libraries are added  */}}
+{{- $Params.Page.Store.Set "_hasRolls"    true -}}
+{{- $Params.Page.Store.Set "_hasShoelace" true -}}
+{{- $Params.Page.Store.Set "_hasAlpine"   true -}}
+
+{{/*  Handle custom templates  */}}
+{{- if $options.custom -}}
+  {{- $canonical = merge $canonical (dict "Page"     $Page)     -}}
+  {{- $canonical = merge $canonical (dict "Position" $Position) -}}
+  {{- $canonical = merge $canonical (dict "Config"   $Config)   -}}
+  {{- $canonical = merge $canonical (dict "Options"  $options)  -}}
+
+  {{- if eq true $options.custom -}}
+    {{- $template = "custom" -}}
+  {{- else -}}
+    {{- $template = $options.custom -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  As the last step, add the canonicalized template to render  */}}
+{{- $template  = printf "%s/%s" $TemplateFolder $template     -}}
+{{- $canonical = merge $canonical (dict "Template" $template) -}}
+
+{{/*  Return the canonicalized values to the markup for rendering  */}}
+{{- return $canonical -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_list.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_list.html
@@ -1,0 +1,54 @@
+{{- $Params     := .                  -}}
+{{- $Position   := $Params.Position   -}} {{/* The markup's position in the Markdown - only for codeblocks  */}}
+{{- $Page       := $Params.Page       -}} {{/* The Page object for the Markdown document the markup is in   */}}
+{{- $options    := $Params.Options    -}} {{/* The pre-merged options, attributes, and preset properties    */}}
+{{- $canonical  := dict               -}} {{/* The return value for the canonicalized list-specific  values */}}
+
+{{/*  Define partials for easier calling/renaming.  */}}
+{{- $getMergedMap         := "platen/utils/getMergedMap"         -}}
+{{- $getSafeAttributes    := "platen/utils/getSafeAttributes"    -}}
+
+{{/*  Rolling-specific partials  */}}
+{{- $normalizeResultTextTemplate := "platen/markup/rolls/utils/_normalizeResultTextTemplate" -}}
+{{- $normalizeSimpleResults      := "platen/markup/rolls/utils/_normalizeSimpleResults"      -}}
+
+{{- with $options.results -}}
+  {{- $ResultParams := dict "Options" $options "Page" $Page          -}}
+  {{- $Results      := partial $normalizeSimpleResults $ResultParams -}}
+  {{- $canonical     = merge $canonical (dict "Results" $Results)    -}}
+{{- else -}}
+  {{- errorf "Specified a roll list at %s without any possible results. Ensure the `results` key has two or more items in it." $Position -}}
+{{- end -}}
+
+{{- with $options.roll -}}
+  {{- $canonical = merge $canonical (dict "Roll" $options.roll) -}}
+{{- else -}}
+  {{- $Roll     := printf "1d%v" (len $canonical.Results) -}}
+  {{- $canonical = merge $canonical (dict "Roll" $Roll)   -}}
+{{- end -}}
+
+{{/*  Handle the result text settings.  */}}
+{{- $resultTextTemplate := "" -}}
+{{- if or (eq $options.result_text true) (not (isset $options "result_text")) -}}
+  {{- $resultTextTemplate = "Roll result is: {{ result }}" -}}
+{{- else -}}
+  {{- $resultTextTemplate = $options.result_text -}}
+{{- end -}}
+{{- with $resultTextTemplate -}}
+  {{- $canonical = merge $canonical (dict "ResultTextTemplate" $resultTextTemplate) -}}
+{{- end -}}
+
+{{/*  Handle the list's attributes  */}}
+{{- $listAttributes := slice -}}
+{{- $ColumnCount    := $options.column_count | default 1   -}}
+{{- if gt $ColumnCount 1 -}}
+  {{- $ListClassAttribute := printf `class="columns count-%v"` $ColumnCount    -}}
+  {{- $listAttributes = $listAttributes | append $ListClassAttribute -}}
+{{- end -}}
+{{/* Handle alternate starts, like 2+ - default to 0 (implicit numbering) */}}
+{{- $attributeParams := dict "Attributes"  $listAttributes "IndentCount" 6       -}}
+{{- $listAttributes   = partial $getSafeAttributes $attributeParams              -}}
+{{- $canonical        = merge $canonical (dict "ListAttributes" $listAttributes) -}}
+
+{{/*  Return the canonicalized values to the markup for rendering  */}}
+{{- return $canonical -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_table.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/canonicalize/_table.html
@@ -1,0 +1,133 @@
+{{- $Params     := .                  -}}
+{{- $Position   := $Params.Position   -}} {{/* The markup's position in the Markdown - only for codeblocks  */}}
+{{- $Page       := $Params.Page       -}} {{/* The Page object for the Markdown document the markup is in   */}}
+{{- $Options    := $Params.Options    -}} {{/* The pre-merged options, attributes, and preset properties    */}}
+{{- $canonical  := dict               -}} {{/* The return value for the canonicalized list-specific  values */}}
+
+{{/*  Roll-specific utility partials  */}}
+{{- $normalizeButtonInfo         := "platen/markup/rolls/utils/_normalizeButtonInfo"         -}}
+{{- $normalizePromptInfo         := "platen/markup/rolls/utils/_normalizePromptInfo"         -}}
+{{- $normalizeRollInfo           := "platen/markup/rolls/utils/_normalizeRollInfo"           -}}
+{{- $normalizeResultTextTemplate := "platen/markup/rolls/utils/_normalizeResultTextTemplate" -}}
+{{- $normalizeSimpleResults      := "platen/markup/rolls/utils/_normalizeSimpleResults"      -}}
+{{- $getIDs                      := "platen/markup/rolls/utils/_getIDs"                      -}}
+{{/*  Define the template folder and default template for this markup  */}}
+{{- $TemplateFolder := "platen/markup/rolls/templates/tables" -}}
+{{- $template       := "default"                              -}}
+
+{{/*  Normalize and canonicalize the results  */}}
+{{- with $Options.results -}}
+  {{- $results := slice                                                       -}}
+  {{- $keys    := slice                                                       -}}
+  {{- $rollKey := $Options.roll_name | default $Options.roll | default "Roll" -}}
+
+  {{/*  Use with/else so we can only iterate on result keys if needed  */}}
+  {{- with $Options.headers -}}
+    {{- $keys = $Options.headers -}}
+  {{- else -}}
+    {{- range $Result := $Options.results -}}
+      {{- if reflect.IsMap $Result -}}
+        {{- range $Key, $_ := $Result -}}
+          {{- $keys = $keys | append $Key | uniq -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/*  Normalize the results.  */}}
+  {{- if gt (len $keys) 1 -}}
+    {{- range $Roll, $Result := $Options.results -}}
+      {{- $entry := dict -}}
+      {{- $normalizing := dict "Roll" $Options.roll "Page" $Page -}}
+      {{- range $key := $keys -}}
+        {{- $Value := index $Result $key | default "-" -}}
+        {{- if not $Options.no_titleize_headers -}}
+          {{- $key = humanize $key | title -}}
+        {{- end -}}
+        {{- $entry  = merge $entry (dict $key $Value)  -}}
+      {{- end -}}
+      {{- $results = $results | append $entry -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $keys          = $keys | default (slice "result")              -}}
+    {{- $ResultParams := dict "Options" $Options "Page" $Page          -}}
+    {{- $results       = partial $normalizeSimpleResults $ResultParams -}}
+  {{- end -}}
+
+  {{/*  Turn the keys into a normalized map to preserve ordering  */}}
+  {{- $keysMap := dict -}}
+  {{- if and (eq 1 (len $keys)) (ne "result" (index $keys 0)) -}}
+    {{- $Display  := index $keys 0 -}}
+    {{- $KeyEntry := dict "Value" "result" "Display" $Display -}}
+    {{- $keysMap   = merge $keysMap (dict "0" $KeyEntry) -}}
+  {{- else -}}
+    {{- range $Index, $key := $keys -}}
+      {{- $display := $key -}}
+      {{- if not $Options.no_titleize_headers -}}
+        {{- $display = humanize $key | title -}}
+      {{- end -}}
+      {{- $keysMap = merge $keysMap (dict (print $Index) (dict "Value" $key "Display" $display)) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{/*  Save the canonicalized roll key, key map, and result map  */}}
+  {{- $canonical = merge $canonical (dict "RollKey" $rollKey "Keys" $keysMap "Results" $results) -}}
+{{- else -}}
+  {{- errorf "Specified a roll table at %s without any possible results. Ensure the `results` key has two or more items in it." $Position -}}
+{{- end -}}
+
+{{/*
+    Handle the result text settings.
+*/}}
+{{- $ResultTextParams   := dict "Canonical" $canonical "Options" $Options "Page" $Page -}}
+{{- $ResultTextTemplate := partial $normalizeResultTextTemplate $ResultTextParams      -}}
+{{- with $ResultTextTemplate -}}
+  {{- $canonical = merge $canonical (dict "ResultTextTemplate" $ResultTextTemplate) -}}
+{{- end -}}
+
+{{- with $Options.roll -}}
+  {{- $canonical = merge $canonical (dict "Roll" $Options.roll) -}}
+{{- else -}}
+  {{- errorf "Missing mandatory 'roll' option for roll table at %s" $Position -}}
+{{- end -}}
+
+{{- with $Options.tabs -}}
+  {{- $tabs := slice -}}
+  {{- if reflect.IsMap $Options.tabs -}}
+    {{- range $Key, $Value := $Options.tabs -}}
+      {{- $tab := dict "Key" $Key -}}
+
+      {{- if reflect.IsMap $Value -}}
+        {{- $tab = merge $tab $Value -}}
+      {{- else -}}
+        {{- $tab = merge $tab (dict "name" $Value) -}}
+      {{- end -}}
+
+      {{- with $tab.results -}}
+        {{/* Nothing to do, already specified */}}
+      {{- else -}}
+        {{- $tabResults := slice -}}
+        {{- if and (isset $Options "roll") (findRE `,` $Options.roll) -}}
+          {{- $Prefix := printf "%v-" $Key -}}
+          {{- range $Result := $canonical.Results -}}
+            {{- if hasPrefix $Result._roll.Display $Prefix -}}
+              {{- $tabResults = $tabResults | append $Result._roll.Display -}}
+            {{- end -}}
+          {{- end -}}
+        {{- else -}}
+          {{/* Figure out how to slice the table into roughly-equal chunks */}}
+        {{- end -}}
+        {{- $tab = merge $tab (dict "results" $tabResults) -}}
+      {{- end -}}
+
+      {{- $tabs = $tabs | append $tab -}}
+    {{- end -}}
+  {{- else -}}
+    {{- range $Index, $Tab := $Options.tabs -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $canonical = merge $canonical (dict "Tabs" $tabs) -}}
+{{- end -}}
+
+{{/*  Return the canonicalized values to the markup for rendering  */}}
+{{- return $canonical -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/codeblock.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/codeblock.html
@@ -1,0 +1,166 @@
+{{- $Params     := .                    -}}
+{{- $Page       := $Params.Page         -}} {{/* The Page object the codeblock markup was included in               */}}
+{{- $Position   := $Params.Position     -}} {{/* The Position of the codeblock markup in the page                   */}}
+{{- $Definition := $Params.Inner        -}} {{/* The text inside the codeblock (between the fences)                 */}}
+{{- $Type       := $Params.Type | lower -}} {{/* The language ID for the codeblock                                  */}}
+{{- $Attributes := $Params.Attributes   -}} {{/* The attributes added to the codeblock after the ID in curly braces */}}
+{{- $Ordinal    := $Params.Ordinal      -}} {{/* The 0-based ordinal for codeblocks in the page the markup's from   */}}
+{{- $MarkupName := "rolls"              -}} {{/* The name of the markup, usually the same as the parent folder      */}}
+{{/*
+    Retrieve settings from configuration.
+
+    Make sure to replace NAME with the name of the markup in the site config.
+    If your default ID isn't the same as the markup name, edit that too.
+
+    Markup should always have at least one default ID and support aliases. If
+    the markup supports differently grouped language IDs, specify the DefaultIDs
+    as a map instead of a slice and set the DefaultKey to the key that is added
+    from aliases when aliases is a slice or string instead of a map.
+*/}}
+{{- $ConfigKey  := printf "platen.markup.%s"  $MarkupName                    -}}
+{{- $Config     := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
+{{- $Aliases    := $Config.aliases                                           -}}
+{{- $DefaultIDs := slice "roll-list" "roll-table"                            -}}
+{{- $DefaultKey := ""                                                        -}}
+{{- $kind       := "table"                                                   -}}
+{{- if in $Type "-" -}}
+  {{- $kind = index (last 1 (split $Type "-")) 0 -}}
+{{- end -}}
+{{/*
+    Define partials for easier calling/renaming.
+
+    - getMergedMarkupIDs returns the canonical list of language IDs that Platen
+      will use to see if a codeblock should be rendered as this markup.
+
+    - getCodeblockInfo parses a codeblock to return the YAML options, if defined,
+      and the Markdown for the codeblock. This makes it possible to implement
+      codeblock markup that can have a larger list of options defined in a YAML
+      block before the inner content instead of a scrolling line of attributes.
+
+    - getMergedCodeblockOptions handles merging the YAML options with the
+      attributes on the codeblock, preferring values set in the YAML options
+      over the attributes.
+
+    - isValidLanguageID loops over the valid language IDs, handling maps and
+      slices both, to see whether a codeblock is valid for this markup. If it
+      is, it returns true.
+
+    - _canonicalize is always markup-specific and must handle selecting the
+      template to render, merging in any site configuration settings that apply
+      to the markup when the markup doesn't override the value, munging the
+      options as needed, and building the list of canonical values to send to
+      the template.
+*/}}
+{{- $getMergedMarkupIDs        := "platen/utils/getMergedMarkupIDs"         -}}
+{{- $getCodeblockInfo          := "platen/utils/getCodeblockInfo"           -}}
+{{- $getMergedCodeblockOptions := "platen/utils/getMergedCodeblockOptions"  -}}
+{{- $isValidLanguageID         := "platen/utils/isValidLanguageID"          -}}
+{{- $canonicalize              := "platen/markup/rolls/canonicalize/_block" -}}
+{{/*
+    Define parameters for retrieving info from the codeblock.
+
+    Set SupportsData to false if your markup doesn't support YAML options.
+    Set SupportsMarkdown to false if your markup is data-only.
+*/}}
+{{- $SupportsData     := true -}}
+{{- $SupportsMarkdown := false -}}
+{{- $InfoParameters   := dict "Definition"       $Definition
+                              "SupportsData"     $SupportsData
+                              "SupportsMarkdown" $SupportsMarkdown
+-}}
+{{/*
+    Define base parameters for merging the YAML options with attributes. The
+    YamlOptions key is always added after the codeblock info is retrieved.
+
+    Delete the lines for PresetDotPathPrefix and PresetKey if your markup
+    doesn't use presets.
+
+    Delete the lines for ValidKeys if you don't want to validate the keys to a
+    strict list of valid options.
+
+    Attributes and Position always need to be passed.
+*/}}
+{{- $PresetDotPathPrefix := printf "platen.%s.%ss" $MarkupName $kind -}}
+{{- $PresetKey           := "preset"                       -}}
+{{- $ValidKeys           := slice                          -}}
+{{- $mergeParameters     := dict "Attributes"          $Attributes
+                                 "Position"            $Position
+                                 "PresetDotPathPrefix" $PresetDotPathPrefix
+                                 "PresetKey"           $PresetKey
+                                 "ValidKeys"           $ValidKeys
+-}}
+
+{{/*
+    Define options for trimming the rendered output. Set TrimLeadingWhitespace
+    to false to leave any leading whitespace for the rendered output. Set
+    TrimTrailingWhitespace to false to leave any trailing whitespace for the
+    rendered output.
+
+    Unless specifically desired, we trim leading and trailing whitespace so the
+    rendered output is more readable.
+*/}}
+{{- $TrimLeadingWhitespace  := true -}}
+{{- $TrimTrailingWhitespace := true -}}
+
+{{/*
+    From this point on, everything should stay the same as defined here.
+
+    Instead of editing the values below, edit the options above and make sure
+    to implement the canonicalize partial for your markup.
+*/}}
+
+{{/*  Retrieve the valid language IDs  */}}
+{{- $MarkupIDParams   := dict "Default" $DefaultIDs "DefaultKey" $DefaultKey "Aliases" $Aliases -}}
+{{- $CacheKey         := printf "%s-codeblock" $MarkupName                                      -}}
+{{- $ValidLanguageIDs := partialCached $getMergedMarkupIDs $MarkupIDParams $CacheKey            -}}
+{{- $CheckIDParams    := dict "ValidLanguageIDs" $ValidLanguageIDs "LanguageID" $Type           -}}
+
+{{/*
+    Define base parameters for canonicalizing the codeblock.
+
+    The Options and Definition keys are always added after the codeblock info is
+    retrieved and the attributes are merged with the YAML options.
+*/}}
+{{- $canonicalizing := dict "Config"   $Config
+                            "Position" $Position
+                            "Page"     $Page
+                            "ValidIDs" $ValidLanguageIDs
+                            "ID"       $Type
+                            "Kind"     "codeblock"
+-}}
+
+{{/*
+    Initialize the rendered code string. This is returned to the caller. If it's empty,
+    this renderer isn't applied. If it has any content, that's used as the rendered
+    output for the codeblock from the Markdown. Only the first renderer that returns
+    content is used.
+*/}}
+{{- $renderedCode := "" -}}
+
+{{/*  If the codeblock is valid for this markup, process it.  */}}
+{{- if (partial $isValidLanguageID $CheckIDParams) -}}
+  {{/*
+      Parse the definition for data and markdown, then merge the attributes
+      with the YAML options. Next, canonicalize the information to select the
+      template to render and provide the values the templates need to render
+      the markup.
+  */}}
+  {{- $info           := partial $getCodeblockInfo $InfoParameters                                   -}}
+  {{- $mergeParameters = merge $mergeParameters (dict "YamlOptions" $info.Data)                      -}}
+  {{- $Merged         := partial $getMergedCodeblockOptions $mergeParameters                         -}}
+  {{- $canonicalizing  = merge $canonicalizing (dict "Options"  $Merged "Definition" $info.Markdown) -}}
+  {{- $Canonicalized  := partial $canonicalize $canonicalizing                                       -}}
+
+  {{/*  Render the codeblock with the template from the canonicalized info  */}}
+  {{- $renderedCode = partial $Canonicalized.Template $Canonicalized -}}
+
+  {{/*  Trim the rendered codeblock as needed  */}}
+  {{- if $TrimLeadingWhitespace -}}
+    {{- $renderedCode = strings.TrimLeft "\n " $renderedCode -}}
+  {{- end -}}
+  {{- if $TrimTrailingWhitespace -}}
+    {{- $renderedCode = strings.TrimRight "\n " $renderedCode -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $renderedCode -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/header.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/header.html
@@ -1,0 +1,22 @@
+{{- $Context          := .                                                         -}}
+{{- $IntegrityPartial := "platen/utils/getIntegrityAttributes"                     -}}
+{{- $CacheKey         := printf "PlatenRollsScript"                                -}}
+{{- $ConfigKey        := "platen.markup.rolls"                                     -}}
+{{- $Config           := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
+{{- $StoreKey         := "_hasRolls"                                               -}}
+{{- $AssetPath        := "scripts/markup/rolls/rolling.js"                         -}}
+{{- $RenderPath       := "scripts/platen/rolling.js"                               -}}
+{{- $Template         := "platen/markup/rolls/templates/header"                    -}}
+{{- $LoadRolls        := $Context.Store.Get $StoreKey                              -}}
+
+{{- if $LoadRolls -}}
+  {{- $Resource  := resources.Get $AssetPath
+                    | resources.Copy $RenderPath
+                    | resources.Fingerprint
+  -}}
+  {{- $Integrity := partialCached $IntegrityPartial $Resource $CacheKey         -}}
+  {{- $Params    := dict "Source" $Resource.RelPermalink "Integrity" $Integrity -}}
+
+  {{/*  Render the template  */}}
+  {{- partialCached $Template $Params $Params -}}
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/image.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/image.html
@@ -1,0 +1,195 @@
+{{- $Params      := .                   -}}
+{{- $Page        := $Params.Page        -}} {{/* The Page the image markup was added to                           */}}
+{{- $Attributes  := $Params.Attributes  -}} {{/* The attributes added between curly braces after the markup       */}}
+{{- $Destination := $Params.Destination -}} {{/* The Source input for the image link markup                       */}}
+{{- $Title       := $Params.Title       -}} {{/* The Title input for the image link markup                        */}}
+{{- $Text        := $Params.Text        -}} {{/* The rendered Alt Text input for the image link markup            */}}
+{{- $Ordinal     := $Params.Ordinal     -}} {{/* The 0-based ordinal for codeblocks in the page the markup's from */}}
+{{- $MarkupName  := "rolls"             -}} {{/* The name of the markup, usually the same as the parent folder    */}}
+{{/*
+    Retrieve settings from configuration.
+
+    Make sure to replace NAME with the name of the markup in the site config.
+    If your default prefix isn't the same as the markup name, edit that too.
+
+    Markup should always have at least one default prefix and support aliases.
+    If the markup supports differently grouped prefixes, specify the
+    DefaultPrefixes as a map instead of a slice and set the DefaultKey to the
+    key that is added from aliases when aliases is a slice or string instead
+    of a map.
+*/}}
+{{- $ConfigKey       := printf "platen.markup.%s" $MarkupName                     -}}
+{{- $Config          := partialCached "platen/param/getKey" $ConfigKey $ConfigKey -}}
+{{- $Aliases         := $Config.aliases                                           -}}
+{{- $DefaultPrefixes := slice "roll"                                              -}}
+{{- $DefaultKey      := ""                                                        -}}
+{{/*
+    Define partials for easier calling/renaming.
+
+    - getMergedMarkupIDs returns the canonical list of language IDs or prefixes
+      that Platen will use to see if a codeblock or image should be rendered as
+      this markup. For images, we always pass the Suffix option as true so it
+      appends the semi-colon for us.
+
+    - getPrefixTrimmedAltText checks to see if the image link is this markup.
+      If it is, the Value key will be set to the trimmed alt text. If it isn't,
+      it returns an empty dict; this lets us use the `with` operator even when
+      the trimmed alt text is an empty string. That can be valid when the
+      markup supports presets.
+
+    - getMergedLinkOptions handles merging preset options with the attributes
+      on the markup, preferring values set in the attributes over the properties
+      from the preset, if any.
+
+    - _canonicalize is always markup-specific and must handle selecting the
+      template to render, merging in any site configuration settings that apply
+      to the markup when the markup doesn't override the value, munging the
+      options as needed, and building the list of canonical values to send to
+      the template.
+*/}}
+{{- $getMergedMarkupIDs      := "platen/utils/getMergedMarkupIDs"                          -}}
+{{- $getPrefixTrimmedAltText := "platen/utils/getPrefixTrimmedAltText"                     -}}
+{{- $getMergedLinkOptions    := "platen/utils/getMergedLinkOptions"                        -}}
+{{- $canonicalize            := printf "platen/markup/%s/canonicalize/_inline" $MarkupName -}}
+{{/*
+    Get the list of valid prefixes for this markup. If the markup supports more
+    than one kind, the prefixes and language IDs must be shared.
+*/}}
+{{- $MarkupIDParams := dict "Default"    $DefaultPrefixes
+                            "DefaultKey" $DefaultKey
+                            "Aliases"    $Aliases
+                            "Suffix"     true
+-}}
+{{- $CacheKey := printf "%s-image" $MarkupName                               -}}
+{{- $Prefixes := partialCached $getMergedMarkupIDs $MarkupIDParams $CacheKey -}}
+{{/*
+    Check to see if the image link is this markup. If it is, the Value key will
+    be set to the trimmed alt text. If it isn't, this will be an empty dict;
+    this lets us use the `with` operator even when the trimmed alt text is an
+    empty string.
+
+    This also returns the matching prefix in the Prefix key, which is useful
+    when you need to take additional actions based on the prefix itself during
+    canonicalization.
+*/}}
+{{- $PrefixCheckParams := dict "Prefixes" $Prefixes "Text" $Text              -}}
+{{- $MarkupInfo        := partial $getPrefixTrimmedAltText $PrefixCheckParams -}}
+{{/*
+    Define base parameters for merging the preset options with attributes and
+    inputs. Preset options are always overridden by the inputs which are
+    overridden by the attributes.
+
+    Make sure that the values for DestinationKey and TextKey are what you want.
+    They can be renamed to anything, but the partial expects to use that name
+    for merging the values from preset options, inputs, and attributes. If
+    you're using the Title input, make sure the TitleKey is correct too.
+
+    Delete the lines for Preset* variables if your markup doesn't use presets.
+    If your markup does use presets, make sure to set the PresetDotPathPrefix
+    to the dot-path root for your presets in the site data. For example, if you
+    want to support finding the preset "bar.baz" in "data/platen/foo", the value
+    should be "platen.foo"
+
+    Delete the lines for Title and TitleKey if your markup ignores that input.
+
+    Delete the lines for ValidAttributes if you don't want to validate the keys
+    to a strict list of valid options. Otherwise, add the valid names to the
+    slice.
+
+    Attributes, Destination, Page, and Text always need to be passed.
+
+    The values pre-assigned to the variables represent the defaults for the
+    partial. If you're using the defaults you can delete them or leave them
+    here.
+*/}}
+{{- $DestinationKey      := "destination"                  -}}
+{{- $PresetDotPathPrefix := "platen.rolls.inline"          -}}
+{{- $PresetDefaultDotPath := "_default"                     -}}
+{{- $PresetKey           := "preset"                       -}}
+{{- $PresetKeysToRender  := slice                          -}}
+{{- $PresetPrefix        := "preset:"                      -}}
+{{- $TextKey             := "roll"                         -}}
+{{- $TitleKey            := "label"                        -}}
+{{- $ValidAttributes     := slice                          -}}
+{{- $MergeParameters     := dict "Attributes"           $Attributes
+                                 "Destination"          $Destination
+                                 "DestinationKey"       $DestinationKey
+                                 "Page"                 $Page
+                                 "PresetDotPathPrefix"  $PresetDotPathPrefix
+                                 "PresetDefaultDotPath" $PresetDefaultDotPath
+                                 "PresetKey"            $PresetKey
+                                 "PresetKeysToRender"   $PresetKeysToRender
+                                 "PresetPrefix"         $PresetPrefix
+                                 "Text"                 $MarkupInfo.Value
+                                 "TextKey"              $TextKey
+                                 "Title"                $Title
+                                 "TitleKey"             $TitleKey
+                                 "ValidAttributes"      $ValidAttributes
+-}}
+
+{{/*
+    Define options for trimming the rendered output. Set TrimLeadingWhitespace
+    to false to leave any leading whitespace for the rendered output. Set
+    TrimTrailingWhitespace to false to leave any trailing whitespace for the
+    rendered output.
+
+    Unless specifically desired, we trim leading and trailing whitespace so the
+    rendered output is more readable.
+*/}}
+{{- $TrimLeadingWhitespace  := true -}}
+{{- $TrimTrailingWhitespace := true -}}
+
+{{/*
+    From this point on, everything should stay the same as defined here.
+
+    Instead of editing the values below, edit the options above and make sure
+    to implement the canonicalize partial for your markup. Delete this comment
+    before merging.
+*/}}
+
+{{/*
+    Define base parameters for canonicalizing the image link. The Options key
+    is always added after preset options are merged with the attributes.
+*/}}
+{{- $canonicalizing := dict "Config"   $Config
+                            "Page"     $Page
+                            "ValidIDs" $Prefixes
+                            "ID"       $MarkupInfo.Prefix
+                            "Kind"     "image"
+-}}
+
+{{/*
+    Initialize the rendered image string. This is returned to the caller. If
+    it's empty, this renderer isn't applied. If it has any content, that's used
+    as the rendered output for the image link from the Markdown. Only the first
+    renderer that returns content is used.
+*/}}
+{{- $renderedImage := "" -}}
+
+{{/*
+    If MarkupInfo is an empty dict, it's because this image link's alt text
+    doesn't have a valid prefix for this markup.
+*/}}
+{{- with $MarkupInfo -}}
+  {{/*
+      Merge the attributes with the preset options, if any. Next, canonicalize
+      the information to select the template to render and provide the values
+      the templates need to render the markup.
+  */}}
+  {{- $MergedOptions  := partial $getMergedLinkOptions $MergeParameters         -}}
+  {{- $canonicalizing  = merge $canonicalizing (dict "Options"  $MergedOptions) -}}
+  {{- $Canonicalized  := partial $canonicalize $canonicalizing                  -}}
+
+  {{/*  Render the image link with the template from the canonicalized info  */}}
+  {{- $renderedImage = partial $Canonicalized.Template $Canonicalized -}}
+
+  {{/*  Trim the rendered image link as needed  */}}
+  {{- if $TrimLeadingWhitespace -}}
+    {{- $renderedImage = strings.TrimLeft "\n " $renderedImage -}}
+  {{- end -}}
+  {{- if $TrimTrailingWhitespace -}}
+    {{- $renderedImage = strings.TrimRight "\n " $renderedImage -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $renderedImage -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/blockButton.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/blockButton.html
@@ -1,0 +1,11 @@
+{{- $Params             := .                                         -}}
+{{- $ButtonAttributes   := $Params.ButtonAttributes   | safeHTMLAttr -}}
+{{- $ButtonLabel        := $Params.ButtonLabel        | safeHTML     -}}
+{{- $XRefID             := $Params.XRefID             | safeJS       -}}
+
+<sl-button @click="rollOn($data, $refs, '{{ $XRefID }}')"
+          {{- with $ButtonAttributes }}
+          {{ $ButtonAttributes -}}
+          {{- end -}}>
+  {{ $ButtonLabel }}
+</sl-button>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/header.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/header.html
@@ -1,0 +1,8 @@
+{{- $Params    := .                                -}}
+{{- $Source    := $Params.Source    | safeHTMLAttr -}}
+{{- $Integrity := $Params.Integrity | safeHTMLAttr -}}
+
+<script src="https://unpkg.com/mathjs@9.3.2/lib/browser/math.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/random-js@2.1.0/dist/random-js.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@dice-roller/rpg-dice-roller@5.2.1/lib/umd/bundle.min.js"></script>
+<script src="{{ $Source }}" {{ $Integrity }}></script>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/inline/custom.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/inline/custom.html
@@ -1,0 +1,44 @@
+{{/*  Delete this comment but leave the next one.  */}}
+{{/*
+    This custom template is a stub. It's here for your convenience only. If
+    you want to define your own template, copy this one to start from. The
+    inputs for your template are limited to the ones defined here, but your
+    template can do whatever you need it to.
+*/}}
+{{- $Params  := . -}}
+{{/*
+    These values are all from the example implementation of the canonicalize
+    partial. Make sure to actually implement the template to your needs.
+
+    Always pass the values meant to be insertable directly in the HTML through
+    safeHTML, safeHTMLAttr (for attributes), safeCSS, safeJS, or safeURL so
+    your values aren't munged unexpectedly.
+
+    Delete this comment or replace it with an explanation of the available
+    variables for people implementing their own custom template to use.
+*/}}
+{{- $Attributes := $Params.Attributes | safeHTMLAttr -}}
+{{- $Content    := $Params.Content    | safeHTML     -}}
+{{- $Classes    := $Params.Classes    | safeHTMLAttr -}}
+{{- $Page       := $Params.Page                      -}}
+{{- $Position   := $Params.Position                  -}}
+{{- $Config     := $Params.Config                    -}}
+{{- $options    := $Params.options                   -}}
+
+{{/*
+    Delete this comment but leave everything after it untouched except for
+    making sure the error message is useful to the user and specifies the
+    right name for the markup.
+*/}}
+{{/*
+    The default custom template raises an error because it's not
+    actually implemented. This stub is for your convenience.
+*/}}
+{{- errorf "Used custom NAME template at %s, but no template defined." $Position -}}
+
+{{/*
+    You don't need to do a return statement, you can just use
+    a custom HTML template if you want. This return is included
+    so Platen doesn't break if the custom template isn't defined.
+*/}}
+{{- return "" -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/inline/default.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/inline/default.html
@@ -1,0 +1,40 @@
+{{- $Params             := .                                         -}}
+{{- $ButtonPlacement    := $Params.ButtonPlacement                   -}}
+{{- $Classes            := $Params.Classes            | safeHTMLAttr -}}
+{{- $ID                 := $Params.ID                 | safeHTMLAttr -}}
+{{- $Prompts            := $Params.Prompts                           -}}
+{{- $Roll               := $Params.Roll                              -}}
+{{- $Results            := $Params.Results                           -}}
+{{- $ResultTextTemplate := $Params.ResultTextTemplate | default ""   -}}
+{{- $Notation           := $Params.Notation           | safeJS       -}}
+{{- $Label              := $Params.Label              | safeHTML     -}}
+{{- $XRefID             := $Params.XRefID             | safeJS       -}}
+{{/*  Define templates for easier maintenance/renaming  */}}
+{{- $TemplatePrefix     := "platen/markup/rolls/templates" -}}
+{{- $ListBlockTemplate  := printf "%s/lists/block" $TemplatePrefix -}}
+{{- $ButtonTemplate     := printf "%s/blockButton" $TemplatePrefix -}}
+{{- $ResultSpanTemplate := printf "%s/resultSpan"  $TemplatePrefix -}}
+{{- $ButtonAttributes   := $Params.ButtonAttributes  | safeHTMLAttr -}}
+{{- $TooltipAttributes  := $Params.TooltipAttributes | safeHTMLAttr -}}
+
+{{/*  Build the blob for alpine to use.  */}}
+{{- $AlpineData := dict
+                   "prompts"              $Prompts
+                   "roll"                 $Roll
+                   "results"              $Results
+                   "result_text_template" $ResultTextTemplate
+                   "result_text"          "Click to roll"
+-}}
+
+<span class="{{ $Classes }}"
+     {{- with $ID }}
+     id="{{ $ID }}"
+     {{- end }}
+     x-data="{{ $AlpineData | jsonify }}"
+     x-ref="{{ $XRefID }}">
+     <sl-tooltip hoist {{ $TooltipAttributes }} :content="result_text">
+        <sl-button @click="rollInline($data, $refs, '{{ $XRefID }}')" {{ $ButtonAttributes }}>
+            {{ $Label }}
+        </sl-button>
+     </sl-tooltip>
+</span>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/lists/block.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/lists/block.html
@@ -1,0 +1,9 @@
+{{- $Params := . -}}
+{{- $ListAttributes := $Params.ListAttributes | safeHTMLAttr -}}
+
+<ol {{ $ListAttributes }}>
+    <template x-for="result in (sortResultsInfo(results))">
+        <li x-text="result.result" :data-roll="JSON.stringify(result._roll)"
+            :data-list-content="`${decodeHTML(result._roll.Display)}. `" data-active="false"></li>
+    </template>
+</ol>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/lists/custom.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/lists/custom.html
@@ -1,0 +1,44 @@
+{{/*  Delete this comment but leave the next one.  */}}
+{{/*
+    This custom template is a stub. It's here for your convenience only. If
+    you want to define your own template, copy this one to start from. The
+    inputs for your template are limited to the ones defined here, but your
+    template can do whatever you need it to.
+*/}}
+{{- $Params  := . -}}
+{{/*
+    These values are all from the example implementation of the canonicalize
+    partial. Make sure to actually implement the template to your needs.
+
+    Always pass the values meant to be insertable directly in the HTML through
+    safeHTML, safeHTMLAttr (for attributes), safeCSS, safeJS, or safeURL so
+    your values aren't munged unexpectedly.
+
+    Delete this comment or replace it with an explanation of the available
+    variables for people implementing their own custom template to use.
+*/}}
+{{- $Attributes := $Params.Attributes | safeHTMLAttr -}}
+{{- $Content    := $Params.Content    | safeHTML     -}}
+{{- $Classes    := $Params.Classes    | safeHTMLAttr -}}
+{{- $Page       := $Params.Page                      -}}
+{{- $Position   := $Params.Position                  -}}
+{{- $Config     := $Params.Config                    -}}
+{{- $options    := $Params.options                   -}}
+
+{{/*
+    Delete this comment but leave everything after it untouched except for
+    making sure the error message is useful to the user and specifies the
+    right name for the markup.
+*/}}
+{{/*
+    The default custom template raises an error because it's not
+    actually implemented. This stub is for your convenience.
+*/}}
+{{- errorf "Used custom NAME template at %s, but no template defined." $Position -}}
+
+{{/*
+    You don't need to do a return statement, you can just use
+    a custom HTML template if you want. This return is included
+    so Platen doesn't break if the custom template isn't defined.
+*/}}
+{{- return "" -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/lists/default.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/lists/default.html
@@ -1,0 +1,42 @@
+{{- $Params             := .                                         -}}
+{{- $ButtonPlacement    := $Params.ButtonPlacement                   -}}
+{{- $Classes            := $Params.Classes            | safeHTMLAttr -}}
+{{- $ID                 := $Params.ID                 | safeHTMLAttr -}}
+{{- $Prompts            := $Params.Prompts                           -}}
+{{- $Roll               := $Params.Roll                              -}}
+{{- $Results            := $Params.Results                           -}}
+{{- $ResultTextTemplate := $Params.ResultTextTemplate | default ""   -}}
+{{- $XRefID             := $Params.XRefID             | safeJS       -}}
+{{/*  Define templates for easier maintenance/renaming  */}}
+{{- $TemplatePrefix     := "platen/markup/rolls/templates" -}}
+{{- $ListBlockTemplate  := printf "%s/lists/block" $TemplatePrefix -}}
+{{- $ButtonTemplate     := printf "%s/blockButton" $TemplatePrefix -}}
+{{- $ResultSpanTemplate := printf "%s/resultSpan"  $TemplatePrefix -}}
+
+{{/*  Build the blob for alpine to use.  */}}
+{{- $AlpineData := dict
+                   "prompts"              $Prompts
+                   "roll"                 $Roll
+                   "results"              $Results
+                   "result_text_template" $ResultTextTemplate
+                   "result_text"          ""
+-}}
+
+<div class="{{ $Classes }}"
+     {{- with $ID }}
+     id="{{ $ID }}"
+     {{- end }}
+     x-data="{{ $AlpineData | jsonify }}"
+     x-ref="{{ $XRefID }}">
+  {{ if eq "above" $ButtonPlacement -}}
+    {{ partial $ButtonTemplate      $Params }}
+    {{ partial $ResultSpanTemplate  $Params }}
+
+    {{ partial $ListBlockTemplate   $Params }}
+  {{- else }}
+    {{ partial $ListBlockTemplate   $Params }}
+
+    {{ partial $ButtonTemplate      $Params }}
+    {{ partial $ResultSpanTemplate  $Params }}
+  {{- end }}
+</div>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/prompts.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/prompts.html
@@ -1,0 +1,20 @@
+{{- $Params             := .                                         -}}
+{{- $ButtonAttributes   := $Params.ButtonAttributes   | safeHTMLAttr -}}
+{{- $ButtonLabel        := $Params.ButtonLabel        | safeHTML     -}}
+{{- $XRefID             := $Params.XRefID             | safeJS       -}}
+{{- $PromptTitle        := $Params.PromptTitle        | safeHTMLAttr -}}
+
+<sl-button @click="showPrompts($data, $refs, '{{ $XRefID }}')"
+           {{- with $ButtonAttributes }}
+           {{ $ButtonAttributes -}}
+           {{- end -}}>
+  {{ $ButtonLabel }}
+</sl-button>
+{{ partial "platen/markup/rolls/templates/resultSpan" $Params }}
+<sl-dialog label="{{ $PromptTitle }}">
+  <template x-for="prompt in prompts">
+    <sl-input x-init="definePrompt($el, prompt)">
+    </sl-input>
+  </template>
+  {{ partial "platen/markup/rolls/templates/blockButton" $Params }}
+</sl-dialog>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/resultSpan.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/resultSpan.html
@@ -1,0 +1,6 @@
+{{- $Params             := .                          -}}
+{{- $ResultTextTemplate := $Params.ResultTextTemplate -}}
+
+{{- with $ResultTextTemplate -}}
+  <span class="result-text" x-html="decodeHTML(result_text)"></span>
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/block.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/block.html
@@ -1,0 +1,22 @@
+{{- $Params := . -}}
+
+<table>
+    <thead>
+        <tr>
+            <th x-text="roll_key"></th>
+            <template x-for="key in keys">
+                <th x-text="key.Display"></th>
+            </template>
+        </tr>
+    </thead>
+    <tbody>
+        <template x-for="result in (sortResultsInfo(results))">
+            <tr :data-roll="JSON.stringify(result._roll)" :data-active="false">
+                <td x-text="decodeHTML(result._roll.Display)"></td>
+                <template x-for="key in keys">
+                    <td x-html="decodeHTML(result[key.Value])"></td>
+                </template>
+            </tr>
+        </template>
+    </tbody>
+</table>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/custom.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/custom.html
@@ -1,0 +1,44 @@
+{{/*  Delete this comment but leave the next one.  */}}
+{{/*
+    This custom template is a stub. It's here for your convenience only. If
+    you want to define your own template, copy this one to start from. The
+    inputs for your template are limited to the ones defined here, but your
+    template can do whatever you need it to.
+*/}}
+{{- $Params  := . -}}
+{{/*
+    These values are all from the example implementation of the canonicalize
+    partial. Make sure to actually implement the template to your needs.
+
+    Always pass the values meant to be insertable directly in the HTML through
+    safeHTML, safeHTMLAttr (for attributes), safeCSS, safeJS, or safeURL so
+    your values aren't munged unexpectedly.
+
+    Delete this comment or replace it with an explanation of the available
+    variables for people implementing their own custom template to use.
+*/}}
+{{- $Attributes := $Params.Attributes | safeHTMLAttr -}}
+{{- $Content    := $Params.Content    | safeHTML     -}}
+{{- $Classes    := $Params.Classes    | safeHTMLAttr -}}
+{{- $Page       := $Params.Page                      -}}
+{{- $Position   := $Params.Position                  -}}
+{{- $Config     := $Params.Config                    -}}
+{{- $options    := $Params.options                   -}}
+
+{{/*
+    Delete this comment but leave everything after it untouched except for
+    making sure the error message is useful to the user and specifies the
+    right name for the markup.
+*/}}
+{{/*
+    The default custom template raises an error because it's not
+    actually implemented. This stub is for your convenience.
+*/}}
+{{- errorf "Used custom NAME template at %s, but no template defined." $Position -}}
+
+{{/*
+    You don't need to do a return statement, you can just use
+    a custom HTML template if you want. This return is included
+    so Platen doesn't break if the custom template isn't defined.
+*/}}
+{{- return "" -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/default.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/default.html
@@ -1,0 +1,48 @@
+{{- $Params             := .                                            -}}
+{{- $ButtonPlacement    := $Params.ButtonPlacement                      -}}
+{{- $Classes            := $Params.Classes            | safeHTMLAttr    -}}
+{{- $ID                 := $Params.ID                 | safeHTMLAttr    -}}
+{{- $Keys               := $Params.Keys                                 -}}
+{{- $Prompts            := $Params.Prompts                              -}}
+{{- $Roll               := $Params.Roll                                 -}}
+{{- $RollKey            := $Params.RollKey                              -}}
+{{- $Results            := $Params.Results                              -}}
+{{- $ResultTextTemplate := $Params.ResultTextTemplate | default ""      -}}
+{{- $XRefID             := $Params.XRefID             | safeHTMLAttr    -}}
+{{- $Tabs               := $Params.Tabs               | default (slice) -}}
+{{/*  Define templates for easier maintenance/renaming  */}}
+{{- $TemplatePrefix     := "platen/markup/rolls/templates/tables" -}}
+{{- $HandlerTemplate    := printf "%s/handler" $TemplatePrefix    -}}
+{{- $ContentTemplate    := printf "%s/block"   $TemplatePrefix    -}}
+{{- with $Tabs -}}
+  {{- $ContentTemplate = printf "%s/tabs" $TemplatePrefix -}}
+{{- end -}}
+
+{{/*  Build the blob for alpine to use.  */}}
+{{- $AlpineData         := dict
+                           "keys"                 $Keys
+                           "prompts"              $Prompts
+                           "roll"                 $Roll
+                           "roll_key"             $RollKey
+                           "results"              $Results
+                           "result_text_template" $ResultTextTemplate
+                           "result_text"          ""
+                           "tabs"                 $Tabs
+-}}
+
+<div class="{{ $Classes }}"
+     {{- with $ID }}
+     id="{{ $ID }}"
+     {{- end }}
+     x-data="{{ $AlpineData | jsonify }}"
+     x-ref="{{ $XRefID }}">
+  {{ if eq "above" $ButtonPlacement -}}
+  {{ partial "platen/markup/rolls/templates/tables/handler" $Params }}
+
+  {{ partial $ContentTemplate $Params }}
+  {{- else }}
+  {{ partial $ContentTemplate $Params }}
+
+  {{ partial "platen/markup/rolls/templates/tables/handler" $Params }}
+  {{- end }}
+</div>

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/handler.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/handler.html
@@ -1,0 +1,8 @@
+{{- $Params := . -}}
+
+{{- with $Params.Prompts -}}
+  {{- partial "platen/markup/rolls/templates/prompts" $Params -}}
+{{- else -}}
+  {{- partial "platen/markup/rolls/templates/blockButton" $Params }}
+  {{  partial "platen/markup/rolls/templates/resultSpan"  $Params }}
+{{- end -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/tabs.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/templates/tables/tabs.html
@@ -1,0 +1,31 @@
+{{- $Params := . -}}
+
+<sl-tab-group>
+    <template x-for="(tab, key) in tabs">
+        <sl-tab slot="nav" :panel="tab.name" x-text="tab.name"></sl-tab>
+    </template>
+    <template x-for="(tab, key) in tabs">
+        <sl-tab-panel :name="tab.name">
+            <table>
+                <thead>
+                    <tr>
+                        <th x-text="roll_key"></th>
+                        <template x-for="key in keys">
+                            <th x-text="key.Display"></th>
+                        </template>
+                    </tr>
+                </thead>
+                <tbody>
+                    <template x-for="result in (sortResultsInfo(filterResults(results, tab.results)))">
+                        <tr :data-roll="JSON.stringify(result._roll)" :data-active="false">
+                            <td x-text="decodeHTML(result._roll.Display)"></td>
+                            <template x-for="key in keys">
+                                <td x-html="decodeHTML(result[key.Value])"></td>
+                            </template>
+                        </tr>
+                    </template>
+                </tbody>
+            </table>
+        </sl-tab-panel>
+    </template>
+</sl-tab-group>

--- a/modules/platen/layouts/partials/platen/markup/rolls/utils/_getIDs.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/utils/_getIDs.html
@@ -1,0 +1,15 @@
+{{- $Params  := .               -}}
+{{- $Options := $Params.Options -}}
+{{- $ids     := dict            -}}
+
+{{- $RandomHash := delimit (shuffle (split (md5 now.Unix) "" )) "" -}}
+{{- $XRefID     := printf "roll-results-%.7s" $RandomHash          -}}
+
+{{- with $Options.id -}}
+  {{- $ids    = merge $ids (dict "ID" $Options.id)   -}}
+  {{- $XRefID = printf "roll-results-%s" $Options.id -}}
+{{- end -}}
+
+{{- $ids = merge $ids (dict "XRefID" $XRefID) -}}
+
+{{- return $ids -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeButtonInfo.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeButtonInfo.html
@@ -1,0 +1,47 @@
+{{- $Params     := .               -}}
+{{- $Options    := $Params.Options -}}
+{{- $Page       := $Params.Page    -}}
+{{- $buttonInfo := dict            -}}
+
+{{- $getSafeAttributes    := "platen/utils/getSafeAttributes"    -}}
+
+{{/*  First, render and add the label.  */}}
+{{- $buttonLabel := $Options.button.label | default "Roll"              -}}
+{{- $buttonLabel := $Page.RenderString $buttonLabel                     -}}
+{{- $buttonInfo   = merge $buttonInfo (dict "ButtonLabel" $buttonLabel) -}}
+
+{{/*  Handle the placement, defaulting to below the list/table  */}}
+{{- $buttonPlacement := $Options.button.placement | default "below"                 -}}
+{{- $buttonInfo       = merge $buttonInfo (dict "ButtonPlacement" $buttonPlacement) -}}
+
+{{/*  Handle the various attributes for the button  */}}
+{{- $buttonAttributes := slice -}}
+{{- with $Options.button.variant -}}
+  {{- $variantAttribute := printf `variant="%s"` $Options.button.variant -}}
+  {{- $buttonAttributes  = $buttonAttributes | append $variantAttribute  -}}
+{{- end -}}
+
+{{- with $Options.button.size -}}
+  {{- $sizeAttribute   := printf `size="%s"` $Options.button.size    -}}
+  {{- $buttonAttributes = $buttonAttributes | append $sizeAttribute  -}}
+{{- end -}}
+
+{{- if eq true $Options.button.outline -}}
+  {{- $buttonAttributes = $buttonAttributes | append "outline" -}}
+{{- end -}}
+
+{{- if eq true $Options.button.pill -}}
+  {{- $buttonAttributes = $buttonAttributes | append "pill" -}}
+{{- end -}}
+
+{{/*  TODO: Handle Icons  */}}
+
+{{- $attributeParams := dict
+                        "Attributes"  $buttonAttributes
+                        "IndentCount" 11
+                        "MultiLine"   true
+-}}
+{{- $buttonAttributes = partial $getSafeAttributes $attributeParams                   -}}
+{{- $buttonInfo       = merge $buttonInfo (dict "ButtonAttributes" $buttonAttributes) -}}
+
+{{- return $buttonInfo -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizePromptInfo.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizePromptInfo.html
@@ -1,0 +1,31 @@
+{{- $Params    := .                 -}}
+{{- $Options   := $Params.Options   -}}
+{{- $Canonical := $Params.Canonical -}}
+
+{{- $promptInfo := dict -}}
+
+{{- with $Options.prompts -}}
+  {{- $prompts := slice -}}
+
+  {{- range $KeyIndex, $Prompt := $Options.prompts -}}
+    {{- $entry := dict -}}
+
+    {{- if reflect.IsMap $Prompt -}}
+      {{- $type := $Prompt.type | default "number" -}}
+      {{- $name := $Prompt.name | default $KeyIndex -}}
+      {{- $label := $Prompt.label | default (title (humanize $name)) -}}
+      {{- $entry = merge $Prompt (dict "type" $type "name" $name "label" $label) -}}
+    {{- else -}}
+      {{- $label := title (humanize $Prompt) -}}
+      {{- $entry = dict "type" "number" "name" $Prompt "label" $label -}}
+    {{- end -}}
+
+    {{- $prompts = $prompts | append $entry -}}
+  {{- end -}}
+
+  {{- $promptInfo    = merge $promptInfo (dict "Prompts" $prompts)         -}}
+  {{- $PromptTitle  := $Options.prompt_title | default $Canonical.RollKey | default "Roll Inputs" -}}
+  {{- $promptInfo    = merge $promptInfo (dict "PromptTitle" $PromptTitle) -}}
+{{- end -}}
+
+{{- return $promptInfo -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeResultTextTemplate.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeResultTextTemplate.html
@@ -1,0 +1,56 @@
+{{- $Params    := .                 -}}
+{{- $Canonical := $Params.Canonical -}}
+{{- $Options   := $Params.Options   -}}
+{{- $Page      := $Params.Page      -}}
+
+{{- $resultTextTemplate := "" -}}
+{{- $temp := ""}}
+{{- with $Options.result_text -}}
+  {{- if ne "true" (print $Options.result_text) -}}
+    {{- $temp = $Options.result_text | $Page.RenderString -}}
+  {{- end -}}
+{{- end -}}
+{{- with $temp -}}
+  {{/*  Nothing to do  */}}
+{{- else -}}
+  {{- $RollKey           := $Canonical.RollKey -}}
+  {{- $Keys              := $Canonical.Keys    -}}
+  {{- $temp = "Roll result is:"  -}}
+  
+  {{- if eq (len $Keys) 1 -}}
+    {{- $Key := index $Keys "0" -}}
+    {{- $temp = printf "%s {{ %s }}" $temp $Key.Value -}}
+  {{- else -}}
+    {{- $info  := slice -}}
+    {{- range $Key := $Keys -}}
+      {{- $info = $info | append (printf "%s ({{ %s }})" $Key.Display $Key.Value) -}}
+    {{- end -}}
+  
+    {{- $info               = delimit $info     ", "     ", and "      -}}
+    {{- $temp = printf "%s %s" $temp $info -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{- if or (eq $Options.result_text true) (not (isset $Options "result_text")) -}}
+  {{- $RollKey           := $Canonical.RollKey -}}
+  {{- $Keys              := $Canonical.Keys    -}}
+  {{- $resultTextTemplate = "Roll result is:"  -}}
+
+  {{- if eq (len $Keys) 1 -}}
+    {{- $Key := index $Keys "0" -}}
+    {{- $resultTextTemplate = printf "%s {{ %s }}" $resultTextTemplate $Key.Value -}}
+  {{- else -}}
+    {{- $info  := slice -}}
+    {{- range $Key := $Keys -}}
+      {{- $info = $info | append (printf "%s ({{ %s }})" $Key.Display $Key.Value) -}}
+    {{- end -}}
+
+    {{- $info               = delimit $info     ", "     ", and "      -}}
+    {{- $resultTextTemplate = printf "%s %s" $resultTextTemplate $info -}}
+  {{- end -}}
+{{- else -}}
+  {{- $resultTextTemplate = $Options.result_text | $Page.RenderString -}}
+{{- end -}}
+
+{{- return $resultTextTemplate -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeRollInfo.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeRollInfo.html
@@ -1,0 +1,66 @@
+{{- $Params   := .              -}}
+{{- $Page     := $Params.Page   -}}
+{{- $Index    := $Params.Index  -}}
+{{- $Key      := $Params.Key    -}}
+{{- $Result   := $Params.Result -}}
+{{- $Roll     := $Params.Roll   -}}
+{{- $rollInfo := dict           -}}
+
+{{- $modifier := 1 -}}
+{{- with $Roll -}}
+  {{- $Matches := findRESubmatch `^(\d+)d\d+` $Roll -}}
+  {{- with $Matches -}}
+    {{- $Match := index $Matches 0 -}}
+    {{- $modifier = index $Match 1 | int -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with $Key -}}
+  {{/*  We need to prefix with non-whitespace so >=4 doesn't render as a block quote  */}}
+  {{/*  {{- $display          := printf "foo %s" $Key | $Page.RenderString -}}
+  {{- $display           = strings.TrimPrefix "foo " $display         -}}  */}}
+  {{- $rollInfo          = dict "Display" $Key                   -}}
+  {{- $MultiRollPattern := `^(\d+)((?:-\d+)+)$`                    -}}
+  {{- $MinOrMaxPattern  := `^(<|>)(=)?(\d+)$`                    -}}
+  {{- $MinAndMaxPattern := `^(\d+)--(\d+)$`                      -}}
+  {{- $MultiRollMatches := findRESubmatch $MultiRollPattern $Key -}}
+  {{- $OrMatches        := findRESubmatch $MinOrMaxPattern  $Key -}}
+  {{- $AndMatches       := findRESubmatch $MinAndMaxPattern $Key -}}
+  {{- if $MultiRollMatches -}}
+    {{- $Values := findRE `\d+` $Key -}}
+    {{- $Value  := apply $Values "int" "." -}}
+    {{- $rollInfo = merge $rollInfo (dict "Value" $Value) -}}
+  {{- else if $OrMatches -}}
+    {{- $Match    := index $OrMatches 0                          -}}
+    {{- $operator := index $Match     1                          -}}
+    {{- $display  := cond (eq ">" $operator)  "&g"      "&l"     -}}
+    {{- $operator  = cond (eq ">" $operator) "Minimum" "Maximum" -}}
+    {{- $Number   := index (last 1 $Match) 0 | int               -}}
+    {{- if eq 3 (len $Match) -}}
+      {{- $operator = printf "Exclusive%s" $operator -}}
+      {{- $display  = printf "%st;"        $display  -}}
+    {{- else -}}
+      {{- $display = printf "%se;" $display -}}
+    {{- end -}}
+    {{- $display = printf "%s%v" $display $Number -}}
+    {{- $rollInfo = merge $rollInfo (dict $operator $Number "Display" $display) -}}
+  {{- else if $AndMatches -}}
+    {{- $Match   := index $AndMatches 0                                           -}}
+    {{- $Minimum := index $Match 1 | int                                          -}}
+    {{- $Maximum := index $Match 2 | int                                          -}}
+    {{- $Display := printf "%v&ndash;%v" $Minimum $Maximum                        -}}
+    {{- $Info    := dict "Minimum" $Minimum "Maximum" $Maximum "Display" $Display -}}
+    {{- $rollInfo = merge $rollInfo $Info                                         -}}
+  {{- else -}}
+    {{- $rollInfo = merge $rollInfo (dict "Value" (int $Key)) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if ne nil $Index -}}
+  {{- $Display  := add $modifier $Index | print           -}}
+  {{- $Value    := int $Display                           -}}
+  {{- $rollInfo  = dict "Display" $Display "Value" $Value -}}
+{{- end -}}
+
+{{- $rollInfo = dict "_roll"   $rollInfo -}}
+{{- return $rollInfo -}}

--- a/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeSimpleResults.html
+++ b/modules/platen/layouts/partials/platen/markup/rolls/utils/_normalizeSimpleResults.html
@@ -1,0 +1,27 @@
+{{- $Params  := .                                       -}}
+{{/*  {{- $Keys    := $Params.Keys | default (slice "result") -}}  */}}
+{{- $Options := $Params.Options                         -}}
+{{- $Page    := $Params.Page                            -}}
+
+{{- $normalizeRollInfo := "platen/markup/rolls/utils/_normalizeRollInfo" -}}
+
+{{- $normalizing := dict "Roll" $Options.roll "Page" $Page -}}
+{{- $results     := slice                                  -}}
+
+{{- if reflect.IsMap $Options.results -}}
+  {{- range $Key, $Result := $Options.results -}}
+    {{- $normalizing = merge $normalizing (dict "Key" $Key)                         -}}
+    {{- $RollInfo   := partial $normalizeRollInfo $normalizing                      -}}
+    {{- $Entry      := merge (dict "result" ($Page.RenderString $Result)) $RollInfo -}}
+    {{- $results     = $results | append $Entry                                     -}}
+  {{- end -}}
+{{- else -}}
+  {{- range $Index, $Result := $Options.results -}}
+    {{- $normalizing = merge $normalizing (dict "Index" $Index)                      -}}
+    {{- $RollInfo   := partial $normalizeRollInfo $normalizing                       -}}
+    {{- $Entry      := merge (dict  "result" ($Page.RenderString $Result)) $RollInfo -}}
+    {{- $results     = $results | append $Entry                                      -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $results -}}

--- a/modules/platen/layouts/partials/platen/param/getRegisteredShortcodes.html
+++ b/modules/platen/layouts/partials/platen/param/getRegisteredShortcodes.html
@@ -15,7 +15,7 @@
 
 {{- $getKey               := "platen/param/getKey"                       -}}
 {{- $ConfigKey            := "platen.shortcodes"                         -}}
-{{- $registeredShortcodes := partialCached $getKey $ConfigKey $ConfigKey -}}
+{{- $registeredShortcodes := partialCached $getKey $ConfigKey $ConfigKey | default (slice) -}}
 
 {{- if $DisabledOnly -}}
   {{- $disabledShortcodes := dict -}}

--- a/modules/platen/layouts/partials/platen/utils/getMergedLinkOptions.html
+++ b/modules/platen/layouts/partials/platen/utils/getMergedLinkOptions.html
@@ -19,6 +19,7 @@
 {{- $DestinationKey      := $Params.DestinationKey      | default "destination" -}}
 {{- $Page                := $Params.Page                                        -}}
 {{- $PresetDotPathPrefix := $Params.PresetDotPathPrefix                         -}}
+{{- $PresetDefaultDotPath := $Params.PresetDefaultDotPath                       -}}
 {{- $PresetKey           := $Params.PresetKey           | default "preset"      -}}
 {{- $PresetKeysToRender  := $Params.PresetKeysToRender                          -}}
 {{- $PresetPrefix        := $Params.PresetPrefix        | default "preset:"     -}}
@@ -76,6 +77,11 @@
 {{- with index $passedOptions $PresetKey -}}
   {{- $PresetDotPath := printf "%s.%s" $PresetDotPathPrefix .                                  -}}
   {{- $presetOptions  = partialCached "platen/utils/getDataPath" $PresetDotPath $PresetDotPath -}}
+{{- else -}}
+  {{- with $PresetDefaultDotPath -}}
+    {{- $PresetDotPath := printf "%s.%s" $PresetDotPathPrefix .                                  -}}
+    {{- $presetOptions  = partialCached "platen/utils/getDataPath" $PresetDotPath $PresetDotPath -}}
+  {{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
This change adds a prototype for the rolling markup, which is being used in the Platenized edition of A Dungeon Game. It also makes various fixes and minor improvements picked up during that work. Full documentation to follow.