### PR TITLE
(MAINT) Fix mobile icons for firefox

### DIFF
--- a/modules/platen/assets/styles/mobile/_header.scss
+++ b/modules/platen/assets/styles/mobile/_header.scss
@@ -8,4 +8,13 @@
       display: block !important;
     }
   }
+  .platen-header {
+    @supports (-moz-appearance:none) {
+      h1 {
+        @at-root .platen-header label {
+          display: block !important;
+        }
+      }
+    }
+  }
 }

--- a/modules/platen/assets/styles/platen/_header.scss
+++ b/modules/platen/assets/styles/platen/_header.scss
@@ -20,3 +20,13 @@
     display: none;
   }
 }
+
+.platen-header {
+  @supports (-moz-appearance:none) {
+    h1 {
+      @at-root label {
+        display: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change adds some firefox-only SCSS rules to hide/unhide the menu and TOC icon buttons on desktop and show them on mobile. It relies on the `@at-root` rule to do so and is scoped to only affect Firefox.