### PR TITLE
(MAINT) Fix assets for non-root sites

### DIFF
--- a/modules/platen/assets/scripts/features/pwa/manifest.json
+++ b/modules/platen/assets/scripts/features/pwa/manifest.json
@@ -1,14 +1,14 @@
 {
   "name": "{{ site.Title }}",
   "short_name": "{{ site.Title }}",
-  "start_url": "{{ "/" | relURL }}",
-  "scope": "{{ "/" | relURL }}",
+  "start_url": "{{ "" | relURL }}",
+  "scope": "{{ "" | relURL }}",
   "display": "standalone",
   "background_color": "#000000",
   "theme_color": "#000000",
   "icons": [
     {
-      "src": "{{ "/favicon.svg" | relURL }}",
+      "src": "{{ "favicon.svg" | relURL }}",
       "sizes": "512x512"
     }
   ]

--- a/modules/platen/assets/scripts/features/pwa/sw-register.js
+++ b/modules/platen/assets/scripts/features/pwa/sw-register.js
@@ -2,6 +2,6 @@
 if (navigator.serviceWorker) {
   navigator.serviceWorker.register(
     "{{ $swJS.RelPermalink }}",
-    { scope: "{{ "/" | relURL }}" }
+    { scope: "{{ "" | relURL }}" }
   );
 }

--- a/modules/platen/assets/styles/fonts/_roboto.scss
+++ b/modules/platen/assets/styles/fonts/_roboto.scss
@@ -5,8 +5,8 @@
   font-weight: 400;
   font-display: swap;
   src: local(''),
-       url('/fonts/roboto-v27-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('/fonts/roboto-v27-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('#{$BaseURLPrefix}fonts/roboto-v27-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('#{$BaseURLPrefix}fonts/roboto-v27-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 /* roboto-700 - latin */
 @font-face {
@@ -15,8 +15,8 @@
   font-weight: 700;
   font-display: swap;
   src: local(''),
-       url('/fonts/roboto-v27-latin-700.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('/fonts/roboto-v27-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('#{$BaseURLPrefix}fonts/roboto-v27-latin-700.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('#{$BaseURLPrefix}fonts/roboto-v27-latin-700.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }
 
 /* roboto-mono-regular - latin */
@@ -26,6 +26,6 @@
   font-weight: 400;
   font-display: swap;
   src: local(''),
-       url('/fonts/roboto-mono-v13-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
-       url('/fonts/roboto-mono-v13-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
+       url('#{$BaseURLPrefix}fonts/roboto-mono-v13-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
+       url('#{$BaseURLPrefix}fonts/roboto-mono-v13-latin-regular.woff') format('woff'); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
 }

--- a/modules/platen/assets/styles/platen.scss
+++ b/modules/platen/assets/styles/platen.scss
@@ -21,6 +21,9 @@
   {{- $shoelace        = merge $shoelace (dict "DarkThemeUrl" $DarkThemeUrl)       -}}
 {{- end -}}
 
+// Add the Base URL prefix - this makes it easier to reference static elements.
+$BaseURLPrefix: "{{ "" | relURL }}";
+
 // Adds the basic SCSS variables. These can be strings or maps. Values in this
 // group must not reference other values, only primitives.
 {{- range $name, $value := $theme.variables.basic_scss -}}


### PR DESCRIPTION
Prior to this change, sites hosted with a Base URL that isn't set to a root URL, like `https://example.com/shop` instead of just `https://example.com`, raised errors for loading fonts and the service worker.

This is because the URLs for the service worker and built-in fontswere always pointing to `/` rather than the relative prefix.

This change:

1. Fixes the service worker templates to use the root of the Base URL instead of `/`
1. Adds a new convenience SCSS variable, `$BaseUrlPrefix`, to the SCSS. This variable can be used for interpolation.
1. Updates the built-in fonts style to use the `$BaseUrlPrefix` instead of looking for the fonts at `/...`.