### PR TITLE
(GH-101) Ensure SCSS partials return unescaped strings

### DIFF
--- a/modules/platen/config/_default/config.yaml
+++ b/modules/platen/config/_default/config.yaml
@@ -1,7 +1,7 @@
 module:
   hugoVersion:
     extended: true
-    min: 0.111.3
+    min: 0.120.4
 
 markup:
   goldmark:

--- a/modules/platen/layouts/partials/platen/utils/styles/fonts.html
+++ b/modules/platen/layouts/partials/platen/utils/styles/fonts.html
@@ -92,4 +92,5 @@
 {{ end }}
 
 {{/* Return the SCSS to render */}}
-{{- delimit $renderStrings "\n\n" -}}
+{{- $renderStrings = delimit $renderStrings "\n\n" | safeCSS -}}
+{{- return $renderStrings -}}

--- a/modules/platen/layouts/partials/platen/utils/styles/import.html
+++ b/modules/platen/layouts/partials/platen/utils/styles/import.html
@@ -12,4 +12,5 @@
 {{- end -}}
 
 {{/*  Return the SCSS to render  */}}
-{{- delimit $renderStrings "\n" -}}
+{{- $renderStrings = delimit $renderStrings "\n" | safeCSS -}}
+{{- return $renderStrings -}}

--- a/modules/platen/layouts/partials/platen/utils/styles/markup.html
+++ b/modules/platen/layouts/partials/platen/utils/styles/markup.html
@@ -12,4 +12,5 @@
 {{ end }}
 
 {{/*  Return the SCSS to render  */}}
-{{- delimit $renderStrings "\n" | safeHTML -}}
+{{- $renderStrings = delimit $renderStrings "\n" | safeCSS -}}
+{{- return $renderStrings -}}

--- a/modules/platen/layouts/partials/platen/utils/styles/shortcodes.html
+++ b/modules/platen/layouts/partials/platen/utils/styles/shortcodes.html
@@ -12,4 +12,5 @@
 {{ end }}
 
 {{/*  Return the SCSS to render  */}}
-{{- delimit $renderStrings "\n" | safeHTML -}}
+{{- $renderStrings = delimit $renderStrings "\n" | safeCSS -}}
+{{- return $renderStrings -}}

--- a/modules/platen/layouts/partials/platen/utils/styles/variables.html
+++ b/modules/platen/layouts/partials/platen/utils/styles/variables.html
@@ -22,4 +22,5 @@
 {{ end }}
 
 {{/*  Return the SCSS to render  */}}
-{{- delimit $renderStrings "\n  " "\n" | safeHTML -}}
+{{- $renderStrings = delimit $renderStrings "\n  " "\n" | safeCSS -}}
+{{- return $renderStrings -}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@ command = "hugo --gc --minify"
 ignore  = "exit 1"
 
 [context.production.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.4"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -13,20 +13,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.4"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.4"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.111.3"
+HUGO_VERSION = "0.120.4"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
Prior to this commit, the styles for Platen broke on Hugo `1.20.4` for malformed import URLs.

The imports became malformed after the switch to returning strings, not HTML templates, for the `delimit` function.

This change:

- Delimits the strings and marks them as safe to use for CSS in the utility partials.
- Uses the `return` statement explicitly, instead of relying on implicit behavior.
- Fixes #101